### PR TITLE
Update vk_face.js

### DIFF
--- a/source/vk_face.js
+++ b/source/vk_face.js
@@ -537,6 +537,7 @@ function vkStyles(){
 			#side_bar ol li#myprofile a.edit {float:right;}\
 			.vk_textedit_panel{box-shadow: 0px -0px 3px #888; background:rgba(255,255,255,0.7); position:absolute; line-height:25px; min-height:22px; padding:2px; margin-top:-35px; padding-right_:23px;}\
          .vk_emoji_mini_icon{background: url('http://vk.com/images/icons/mono_iconset.gif') no-repeat 50% -362px; width: 12px; height: 12px; margin: 6px;}\
+         .emoji_tt_wrap{z-index:1000}\
          /*.vk_textedit_panel.emoji_no_tabs .emoji_block_cont {margin-top: 16px !important;}*/\
          a.vk_edit_btn{display:block; background-color:transparent; border:1px solid transparent; height:20px; width:20px; float:left;}\
 			a.vk_edit_btn:hover{background-color:#FFF; border:1px solid #DDD;}\


### PR DESCRIPTION
Исправляет возможность ввода смайлов под фотографиями, когда слой emoji попадает на слой перехода влево.
Причина - стандартный z-index у emoji_tt_wrap(z-index:110}. у #pv_left_nav(z-index:620}
