### PR TITLE
Фикс для кнопки "подписаться на пост"

### DIFF
--- a/source/vk_page.js
+++ b/source/vk_page.js
@@ -605,6 +605,7 @@ function vkPostSubscribeBtn(node) {      // Добавление кнопки "�
     for (var i = 0; i < els.length; i++) {
         var parentContainer = els[i];
         var id = parentContainer.innerHTML.match(/(-?\d+)_(\d+)'/);    // id владельца и записи, для которой создается кнопка
+        if (id != null)
         parentContainer.appendChild(vkCe('div', {
                 "title":    IDL('AddToSubscribtions'),
                 "class":    "post_subscribe fl_r",


### PR DESCRIPTION
Дополнение к моему предыдущему реквесту https://github.com/VkOpt/VkOpt/pull/7.
На странице поиска есть посты типа "ответ на запись", к таким постам не надо делать кнопку "подписаться", потому что она просто не сработает. К тому же из-за таких постов вываливается ошибка.
