### PR TITLE
Галочка "Не скрывать" в диалоге выбора музыки для прикрепления

### DIFF
--- a/source/vk_main.js
+++ b/source/vk_main.js
@@ -897,6 +897,10 @@ function vkAudioChooseProcess(answer,url,q){
        // Вставка галочки "Не скрывать"
        p.insertBefore(vkCe('span', {"class": 'divide'}, '|'), p.firstChild)
        p.insertBefore(vkCe('a', {"class": 'checkbox', onclick: 'checkbox(this); window.vk_prevent_addmedia_hide=isChecked(this);'}, '<div></div>' + IDL('PreventHide')), p.firstChild);
+       vkaddcss('.audio_choose_added {' +
+                    'max-width: none !important;' +
+                    'padding: 0 !important;' +
+                '}');
        Inj.Wait('boxQueue.hideLast', function () {  // отключение скрывания окна выбора аудио при добавлении
            Inj.Start('boxQueue.hideLast', 'if (window.vk_prevent_addmedia_hide) return;');
        });


### PR DESCRIPTION
Галочка, чтобы при прикреплении аудиозаписи каждый раз заново не открывать это окно. При добавлении вместо ссылки "добавить аудиозапись" появляется слово "аудиозапись" - я на это никак не повлиял, так работает вконтакте. Думаю, что можно так и оставить и ничего с этим не делать, какая разница что там написано.
![default](https://cloud.githubusercontent.com/assets/2682026/4519666/71c3f8a2-4cc5-11e4-805e-055b104f884a.png)

P.S. За основу была взята функция vkWallAddPreventHideCB, которая была добавлена в 2011 году, но почему-то всё это время была закомментирована.:worried:
