### PR TITLE
Клонирование массивов нативной функцией

### DIFF
--- a/source/vk_face.js
+++ b/source/vk_face.js
@@ -1251,8 +1251,7 @@ function vkMenu(){//vkExLeftMenu
   
   
   var ass=nav.getElementsByTagName('a');
-  var items=[];
-  for (var i=0; i<ass.length;i++) items.push(ass[i]);
+  var items=ass.slice();
   for (var i=0;i<items.length;i++) if (items[i].parentNode.tagName=='LI' || items[i].parentNode.tagName=='TD'){
     var item=items[i];
     var page=item.href.match(/\/([A-Za-z]+)(\.php|\d+|\?|$)/);

--- a/source/vk_lib.js
+++ b/source/vk_lib.js
@@ -1147,11 +1147,6 @@ String.prototype.leftPad = function (l, c) {
 	  }
 	}
 
-	function vkArr2Arr(arr){
-	  var new_arr=[]; 
-	  for (var i=0; i<arr.length; i++) new_arr.push(arr[i]);
-	  return new_arr;
-	}
 	function vkMakeContTabs(trash){
 	  if (!window.vkContTabsCount) {
 		vkContTabsCount=1;
@@ -1161,12 +1156,11 @@ String.prototype.leftPad = function (l, c) {
 	  vkContTabsSwitch=function(idx,show_all){
 			var ids=idx.split("_");
 			if (show_all){
-			  nodes=vkArr2Arr(geByClass("noactivetab",ge('tabcontainer'+ids[0])));
-			  var nds=[]; for (var i=0; i<nodes.length; i++) nds.push(nodes[i]);
-			  for (var i=0; i<nodes.length; i++)  
+			  nodes=geByClass("noactivetab",ge('tabcontainer'+ids[0])).slice();
+			  for (var i=0; i<nodes.length; i++)
 				nodes[i].className="activetab";
 			} else {
-			  var nodes=vkArr2Arr(geByClass("activetab",ge('tabcontainer'+ids[0])));
+			  var nodes=geByClass("activetab",ge('tabcontainer'+ids[0])).slice();
 			  for (var i=0; i<nodes.length; i++) nodes[i].className="noactivetab"; 
 			  //while(nodes[0]) nodes[0].className="noactivetab";
 			}

--- a/source/vk_media.js
+++ b/source/vk_media.js
@@ -3583,7 +3583,7 @@ function vkAudioDelDup(add_button,btn){
 		lockButton(btn);
 		var dcount=0;
 		var adata={};
-		var divs = vkArr2Arr(geByClass('play_new'));
+		var divs = geByClass('play_new').slice();
 		for (var i=0; i<divs.length; i++){
 			if (divs[i].id && divs[i].id.split('play')[1]) var id=divs[i].id.split('play')[1];
 			else continue;
@@ -3603,7 +3603,7 @@ function vkAudioDelDup(add_button,btn){
 		var adata={};
 		var urls=[];
 		var dcount=0;
-		var divs = vkArr2Arr(geByClass('play_new'));
+		var divs = geByClass('play_new').slice();
 		for (var i=0; i<divs.length; i++){
 			if (divs[i].id && divs[i].id.split('play')[1]) var id=divs[i].id.split('play')[1];
 			else continue;

--- a/source/vk_page.js
+++ b/source/vk_page.js
@@ -1401,7 +1401,6 @@ function vkFrProfile(){
   var c2 = geByClass('page_list_module')[0];
   if (c2) c2.id="page_list_module";
   
-  //els=vkArr2Arr(els);
   var mod=function(el,postfix){
     if (postfix=='online' && el.parentNode.id=='profile_friends') el.parentNode.id='profile_friends_online';
     vkNextEl(el).id='friends_profile_'+postfix;
@@ -2504,7 +2503,7 @@ vk_groups = {
                
                
                //ge('vk_scan').innerHTML=vkProgressBar(1,1,310,' ');
-               for (var i=0;i<ms.length;i++) ids.push(ms[i]);
+               ids=ms.slice();
                if (!ms[0] /*|| ids.length>=500*/){ 
                   process();	
                   return;	


### PR DESCRIPTION
Клонирование массивов заменено на метод slice() а раньше для этого использовались циклы и функция vkArr2Arr - она тоже удалена.
На 1165 строке файла vk_lib.js удалена переменная nds, в которую клонируется массив, но которая потом нигде не используется.
После 1170 строки файла vk_lib.js ничего не изменено, но моя IDE (PhpStorm) автоматически нормализует символы конца строк, чтобы они по всему файлу были одни и те же. Поэтому все эти строки в списке изменений.
