### PR TITLE
Не лепить юзер-меню к ссылкам на инстаграм

### DIFF
--- a/source/vk_users.js
+++ b/source/vk_users.js
@@ -16,7 +16,7 @@ var isUserRegEx=[
 /\.php($|\?)/i,
 /\/$/i,
 /id\d+/i,
-/http.{3}\w+\.vk.*\/.?/i
+/http.{3}\w+\.vk.*\/.?|http:\/\/instagram\.com|http:\/\/twitter\.com/i
 ];
 function isUserLink(url){
 	if ((!(isUserRegEx[0].test(url) || isUserRegEx[1].test(url) || isUserRegEx[2].test(url) || isUserRegEx[3].test(url) || isUserRegEx[4].test(url)) || 


### PR DESCRIPTION
На странице профиля около ссылки на инстаграм находится треугольник, при наведении на который появляется надпись "пользователь не найден", оно и понятно - такой пользователь существует только в инстаграме. 
