### PR TITLE
Грузить изображения не только по HTTP

### DIFF
--- a/source/vk_face.js
+++ b/source/vk_face.js
@@ -210,23 +210,23 @@ function vkStyles(){
    .vk_magglass_icon{background: url('/images/magglass_2x.png') no-repeat 50% 50%; background-size:11px 11px; margin-right: 4px; display: inline-block; vertical-align: middle; width: 11px; height: 11px; }\
    .vk_like_icon_white{background: url('/images/icons/like_2x.png') 1px -10px no-repeat transparent; background-size: 10px 32px; height: 10px; width: 11px; display: inline-block; vertical-align: middle;}\
    .vk_comm_icon_white{background: url('/images/fixedmenu_2x.png') 100% -282px no-repeat transparent; background-size: 11px 322px; height: 11px; width: 11px; display: inline-block; vertical-align: middle;}\
-   .vk_x_btn{background: url(http://vk.com/images/hide_to.gif) no-repeat 50% 50%; display: inline-block; vertical-align: middle; width: 10px; height: 10px; }\
+   .vk_x_btn{background: url(/images/hide_to.gif) no-repeat 50% 50%; display: inline-block; vertical-align: middle; width: 10px; height: 10px; }\
    .vk_x_btn{opacity:0.5; cursor:pointer;}\
    .vk_x_btn:hover{opacity:1;}\
    .vk_cancel_ico{\
-      background: url(http://vk.com/images/tasks_icons.gif) no-repeat 0px -69px;\
+      background: url(/images/tasks_icons.gif) no-repeat 0px -69px;\
       display: inline-block;\
       width: 13px; height: 11px;\
       margin-bottom:-2px;\
    }\
    .vk_ok_ico{\
-      background: url(http://vk.com/images/tasks_icons.gif) no-repeat 0px -43px;\
+      background: url(/images/tasks_icons.gif) no-repeat 0px -43px;\
       display: inline-block;\
       width: 13px; height: 11px;\
       margin-bottom:-2px;\
    }\
-   .vk_ok_ico{background: url(http://vk.com/images/icons/check_balanced.gif) no-repeat 0px -2px;}\
-   .vk_cancel_ico{background: url(http://vk.com/images/hide_to.gif) no-repeat 0px -2px;}\
+   .vk_ok_ico{background: url(/images/icons/check_balanced.gif) no-repeat 0px -2px;}\
+   .vk_cancel_ico{background: url(/images/hide_to.gif) no-repeat 0px -2px;}\
    .vk_profile_links a{padding:3px;}\
    .vk_profile_links a:hover{background-color:#E1E7ED; text-decoration:none;}\
    .vk_profile_links{line-height:20px;}\
@@ -454,7 +454,7 @@ function vkStyles(){
       \
       #vksetts_sbox .vksetts_sinp{width:583px;}\
       .box_body #vksetts_sbox .vksetts_sinp {width: 592px;}\
-      .vk_clear_input{   background: url(\"http://st0.vk.me/images/icons/input_clear.gif\") 6px 6px no-repeat transparent;\
+      .vk_clear_input{   background: url(\"//st0.vk.me/images/icons/input_clear.gif\") 6px 6px no-repeat transparent;\
          cursor: pointer;   display: none;   height: 19px;   margin: -1px 0px 0px 583px;   opacity: 0.6;   padding: 2px;   position: absolute;   width: 19px;   z-index: 95;\
       }\
       .box_body .vk_clear_input{margin-left: 595px;}\
@@ -466,8 +466,8 @@ function vkStyles(){
 	var shut='\
 		.shut .module_body, .shut #profile_photos_upload_wrap{	display: none !important;}\
 		.shut { padding-bottom: 3px !important; }\
-      .vk_shut_btn{ display:block; background:url("http://vkontakte.ru/images/flex_arrow_open.gif") no-repeat -6px 2px; width:20px; height:20px; margin:-4px 0; }\
-      .shut .vk_shut_btn{ background-image:url("http://vkontakte.ru/images/flex_arrow_shut.gif");}\
+      .vk_shut_btn{ display:block; background:url("/images/flex_arrow_open.gif") no-repeat -6px 2px; width:20px; height:20px; margin:-4px 0; }\
+      .shut .vk_shut_btn{ background-image:url("/images/flex_arrow_shut.gif");}\
 		#profile_wall.shut div,#profile_photos_module.shut #profile_photos{display: none !important;}\
 		#profile_wall.shut div.module_header, #profile_photos_module.shut div.module_header {display: block !important;}\
 		.module_header.shutable .header_top{ background: #e1e7ed;	}\
@@ -549,7 +549,7 @@ function vkStyles(){
 			}\
 			#side_bar ol li#myprofile a.edit {float:right;}\
 			.vk_textedit_panel{box-shadow: 0px -0px 3px #888; background:rgba(255,255,255,0.7); position:absolute; line-height:25px; min-height:22px; padding:2px; margin-top:-35px; padding-right_:23px;}\
-         .vk_emoji_mini_icon{background: url('http://vk.com/images/icons/mono_iconset.gif') no-repeat 50% -362px; width: 12px; height: 12px; margin: 6px;}\
+         .vk_emoji_mini_icon{background: url('/images/icons/mono_iconset.gif') no-repeat 50% -362px; width: 12px; height: 12px; margin: 6px;}\
          .emoji_tt_wrap{z-index:1000}\
          /*.vk_textedit_panel.emoji_no_tabs .emoji_block_cont {margin-top: 16px !important;}*/\
          a.vk_edit_btn{display:block; background-color:transparent; border:1px solid transparent; height:20px; width:20px; float:left;}\
@@ -579,7 +579,7 @@ function vkStyles(){
          .zoom_ico_white{\
             width:14px; \
             height:14px; \
-            background:url('http://st0.userapi.com/images/icons/photo_icons.png') 0 -62px;\
+            background:url('//st0.userapi.com/images/icons/photo_icons.png') 0 -62px;\
             opacity:0.75;\
             -webkit-transition: opacity 100ms linear;\
             -moz-transition: opacity 100ms linear;\
@@ -917,8 +917,8 @@ function vkMenu(){//vkExLeftMenu
          .vkico_notes,.vkico_groups,.vkico_events,\
          .vkico_feed, .vkico_newsfeed,.vkico_fave,.vkico_custom_link,\
          .vkico_settings,.vkico_apps,.vkico_docs,\
-         .vkico_wall,.vkico_gifts,.vkico_vkplug,.vkico_vkopt,.vkico_app,.vkico_ads,.vkico_pages,.vkico_support{background:url("http://vk.com/images/icons/mono_iconset.gif") no-repeat;}\
-         .is_2x .vkicon{background-image: url("http://vk.com/images/icons/mono_iconset_2x.png");  background-size: 12px 374px;}\
+         .vkico_wall,.vkico_gifts,.vkico_vkplug,.vkico_vkopt,.vkico_app,.vkico_ads,.vkico_pages,.vkico_support{background:url("/images/icons/mono_iconset.gif") no-repeat;}\
+         .is_2x .vkicon{background-image: url("/images/icons/mono_iconset_2x.png");  background-size: 12px 374px;}\
          .left_row  .vkicon{margin: 4px 3px -4px 0px;}\
          \
          .vkico_profile{background-position:0 2px;}\

--- a/source/vk_main.js
+++ b/source/vk_main.js
@@ -1269,7 +1269,7 @@ vk_im={
          var id='add_media_type_' +  cur.imMedia.menu.id + '_nohide';
          if (!ge(id)){
             // ADD WALL POST
-            var a=vkCe('a',{'onclick':'vk_im.attach_wall();','class':'add_media_item','style':"background-image: url('http://vk.com/images/icons/attach_icons.png'); background-position: 3px -130px;"},'<nobr>'+IDL('WallPost')+'</nobr>');
+            var a=vkCe('a',{'onclick':'vk_im.attach_wall();','class':'add_media_item','style':"background-image: url('/images/icons/attach_icons.png'); background-position: 3px -130px;"},'<nobr>'+IDL('WallPost')+'</nobr>');
             p.appendChild(a);
             
             var a=vkCe('a',{id:id,'style':'border-top:1px solid #DDD;'},html);

--- a/source/vk_media.js
+++ b/source/vk_media.js
@@ -1275,9 +1275,9 @@ vk_ph_comms = {
                //*
                if (!users[com.from_id]){ 
                   if (com.from_id<0)
-                     users[com.from_id]=['Admin','http://vk.com/images/camera_c.gif'];
+                     users[com.from_id]=['Admin','/images/camera_c.gif'];
                   else
-                     users[com.from_id]=['[id'+com.from_id+']','http://vk.com/images/camera_c.gif'];
+                     users[com.from_id]=['[id'+com.from_id+']','/images/camera_c.gif'];
                }
                html+=tpl.replace(/%id/g,cur.oid+'_'+com.cid+'review')
                         .replace(/%ava/g,users[com.from_id][1])
@@ -1287,7 +1287,7 @@ vk_ph_comms = {
                         .replace(/%date/g, (new Date(com.date*1000)).format('dd.mm.yyyy HH:MM'))
                         .replace(/%pid/g,cur.oid+'_'+com.pid) //'-1_2'
                         .replace(/%oid/g,cur.oid)
-                        .replace(/%src/g,photos[com.pid+'']||"http://vk.com/images/no_photo.png");
+                        .replace(/%src/g,photos[com.pid+'']||"/images/no_photo.png");
                //*/         
             }
             callback('<div>'+html+'</div>');
@@ -2716,7 +2716,7 @@ function vkVideoAddOpsBtn(){
       var oid=cur.oid;
       var aid=((cur.vSection || "").match(/album_(\d+)/) || [])[1];
       
-      var btn=vkCe('a',{id:'vk_video_ops', "class":'nobold _fl_r'},'[ <img src="http://vk.com/images/icons/help_stest_tick.gif"> ]');
+      var btn=vkCe('a',{id:'vk_video_ops', "class":'nobold _fl_r'},'[ <img src="/images/icons/help_stest_tick.gif"> ]');
       
       var p_options = [];
       if (getSet(66)=='y'){
@@ -4461,7 +4461,7 @@ if (!window.vkopt_plugins) vkopt_plugins={};
    #vk_lastfm_small_icons{position:absolute; margin-left:-16px;}\
    #gp.reverse #vk_lastfm_small_icons{margin-left: 133px;}\
    #vk_lastfm_icons{position:absolute; margin-left:-40px; height:16px; width:40px;}\
-   .lastfm_fav_icon{cursor:pointer; background:url(\'http://vk.com/images/icons/like.gif\'); width:10px; height:10px; margin-top:4px; margin-left:1px; opacity:0.4 }\
+   .lastfm_fav_icon{cursor:pointer; background:url(\'/images/icons/like.gif\'); width:10px; height:10px; margin-top:4px; margin-left:1px; opacity:0.4 }\
    .lastfm_fav_icon:hover{opacity:0.7;}\
    .lastfm_fav_icon.loved{opacity:1;}\
    \

--- a/source/vk_page.js
+++ b/source/vk_page.js
@@ -956,7 +956,7 @@ function status_icq(node) { //add image-link 'check status in ICQ'
     t=el.innerHTML || '';
     t=t.replace(/\D+/g,'') || '';
     if(t.length)                                                                                                                                                   // http://kanicq.ru/invisible/favicon.ico
-      el.innerHTML+=' <a href="http://kanicq.ru/invisible/'+t+'" title="'+IDL("CheckStatus")+'" target=new><img src="http://status.icq.com/online.gif?img=26&icq='+t+'&'+Math.floor(Math.random()*(100000))+'" alt="'+IDL("CheckStatus")+'"></a>';
+      el.innerHTML+=' <a href="http://kanicq.ru/invisible/'+t+'" title="'+IDL("CheckStatus")+'" target=new><img src="'+location.protocol+'//status.icq.com/online.gif?img=26&icq='+t+'&'+Math.floor(Math.random()*(100000))+'" alt="'+IDL("CheckStatus")+'"></a>';
   } 
   //*
   if(skype) {	
@@ -4407,8 +4407,8 @@ function vk_tag_api(section,url,app_id){
 
          code += !dk.is_enabled()?"":"\
          .antilike,#al_adv_side{display:none !important}\
-         .disliked_users_loading{background: url(http://vk.com/images/upload_inv_mono.gif) no-repeat 50% 50%;}\
-         .disliked_users_big_loader{background-image: url(http://vk.com/images/progress7.gif); background-repeat:no-repeat; background-position:50% 50%;}\
+         .disliked_users_loading{background: url(/images/upload_inv_mono.gif) no-repeat 50% 50%;}\
+         .disliked_users_big_loader{background-image: url(/images/progress7.gif); background-repeat:no-repeat; background-position:50% 50%;}\
          .dislike_list{height:100%}\
          \
          .post_dislike_icon,.post_dislike_count,.post_dislike_link{\

--- a/source/vk_skinman.js
+++ b/source/vk_skinman.js
@@ -508,7 +508,7 @@ function vkShowSkinMan(filter,page){
      if (vkMyStyles[i].pid)
          vkMyStyles[i].pid=vkMyStyles[i].pid.match(/-?\d+_\d+/)[0];
      if (vkMyStyles[i].pid) pids.push(vkMyStyles[i].pid);
-     var Thumb=(vkMyStyles[i].thumb)?vkMyStyles[i].thumb:"http://vkontakte.ru/images/question_a.gif";
+     var Thumb=(vkMyStyles[i].thumb)?vkMyStyles[i].thumb:"/images/question_a.gif";
      var Screen=(vkMyStyles[i].screen)?vkMyStyles[i].screen:null;
      var Name=(vkMyStyles[i].name)?vkMyStyles[i].name:IDL("Noname");
      var Author=(vkMyStyles[i].author)?vkMyStyles[i].author:"N/A";

--- a/source/vkopt.js
+++ b/source/vkopt.js
@@ -306,10 +306,10 @@ var TextPasteSmiles={
 					  position:fixed; z-index:1000; right:0px; top:0px;}\
 			#vkDebug .debugPanel{height:'+sHEIGHT+'px; background:#F0F0F0}\
 			#vkDebug .debugPanel span{line-height:18px; font-weight:bold; color:#999; padding-left:5px;}\
-			#vkDebug .mbtn{background:#FFF url("http://vkontakte.ru/images/icons/x_icon5.gif") 0px -63px no-repeat;\
+			#vkDebug .mbtn{background:#FFF url("/images/icons/x_icon5.gif") 0px -63px no-repeat;\
 					  cursor: pointer; height: 21px; width: 21px;\
 					  float:right;}\
-			#vkDebug .hbtn{background:#FFF url("http://vkontakte.ru/images/icons/x_icon5.gif") 0px -105px no-repeat;\
+			#vkDebug .hbtn{background:#FFF url("/images/icons/x_icon5.gif") 0px -105px no-repeat;\
 					  cursor: pointer; height: 21px; width: 21px;\
 					  float:right;}\
 			#vkDebug .log{border: 1px solid #DDD; margin: 5px; min-width:'+(WIDTH-10)+'px; max-height:'+HEIGHT+'px; overflow:auto;}\


### PR DESCRIPTION
Из-за того, что некоторые иконки грузятся по http при https соединении, в браузере написано, что соединение не полностью зашифровано. Поэтому `http://` заменено на `//` и убраны `http://vk.com`.
Но не все картинки теперь грузятся по https, например все иконки на вебмани грузятся по http, потому что по https таких файлов почему-то нет, а есть другие, новые, размером 24х24 (а здесь используется 16х16). И еще кое-где я не менял, потому что не уверен, что это не скажется на функционале.
