### PR TITLE
Повышение качества кода

### DIFF
--- a/source/vk_face.js
+++ b/source/vk_face.js
@@ -1979,7 +1979,7 @@ function SmileNode(mainNode,childItem,searchWord){
  
           mainNode.replaceChild(smile,mainNode.childNodes[childItem+1]);
           //childItem = childItem*1+2;
-          if(mainNode.childNodes[childItem] && mainNode.childNodes[childItem].nodeValue.match(regex)!=-1){
+          if(mainNode.childNodes[childItem] && regex.test(mainNode.childNodes[childItem].nodeValue)){
               childItem = SmileNode(mainNode,childItem,searchWord);
           }
       }

--- a/source/vk_lib.js
+++ b/source/vk_lib.js
@@ -392,9 +392,9 @@ var vkMozExtension = {
 	}
    
    function vkopt_brackets(s){
-      var s=vkCutBracket(s,2);
-      if (!CUT_VKOPT_BRACKET) s='[ '+s+' ]';
-      return s;
+      var s1=vkCutBracket(s,2);
+      if (!CUT_VKOPT_BRACKET) s1='[ '+s1+' ]';
+      return s1;
    }
 
 	function vkExtendLang(obj) {
@@ -666,7 +666,7 @@ var vkMozExtension = {
 		if (nDays==null || nDays==0) nDays=365;
 		expire.setTime(today.getTime()+ 3600000*24*nDays);
 		document.cookie = cookieName+ "="+ escape(cookieValue)+
-		";expires="+ expire.toGMTString()+
+		";expires="+ expire.toUTCString()+
 		((domain) ? ";domain=" + domain : ";domain="+location.host);
 		}
 		if (cookieName=='remixbit') SettBit=cookieValue;//vksetCookie('remixbit',SettBit);
@@ -1588,8 +1588,8 @@ function vk_oauth_api(app_id,scope){
       },
       check:function(){
          var dloc=document.location.href;
-         if (dloc.match(/\?xfr_query=/) || !dloc.match(/access_token/)) return;
-         if (dloc.match("login_success\.html") || dloc.match("blank\.html")){		
+         if (/\?xfr_query=/.test(dloc) || !/access_token/.test(dloc)) return;
+         if (/login_success\.html/.test(dloc) || /blank\.html/.test(dloc)){
                parent.window.postMessage({act:"oapi_login_success",href:dloc},"*");	
          }
       },
@@ -1806,8 +1806,8 @@ var vk_api_permissions = {
       return str_scope.join(',');
    },
    // Преобразует числовые права доступа приложения в число
-   to_int: function(str_scope){
-      var str_scope = str_scope.replace(/^\s+|\s+$/g, '').split(/\s*,\s*/);
+   to_int: function(_str_scope){
+      var str_scope = _str_scope.replace(/^\s+|\s+$/g, '').split(/\s*,\s*/);
       var int_scope = 0;
       var types = vk_api_permissions.types;
       for (var i = 0; i < str_scope.length; i++){
@@ -2165,12 +2165,11 @@ var XFR={
 					var all=r.getAllResponseHeaders();
 					var len=r.getResponseHeader('Content-Length');
 					var data=['xfr',req_id,all,len];
-					parent.window.postMessage(JSON.Str(data),"*");
 				} else {
 					var data=['xfr',req_id,t];
-					parent.window.postMessage(JSON.Str(data),"*");
 					//callback(t);
 				}
+				parent.window.postMessage(JSON.Str(data),"*");
 			});
 		}
 	}

--- a/source/vk_main.js
+++ b/source/vk_main.js
@@ -221,7 +221,7 @@ function vkProcessResponseNode(node,url,q){
 function vkLocationCheck(){
   if (vkCheckInstallCss()) return true;
   XFR.check();
-  if (location.href.match('/away')) if (getSet(6) == 'y'){
+  if (/\/away/.test(location.href) && getSet(6) == 'y'){
 	location.href=unescape(vkLinksUnescapeCyr(location.href.split('to=')[1].split(/&h=.{18}/)[0]).split('&post=')[0]);
 	return true;
   }
@@ -258,7 +258,7 @@ function VkOptMainInit(){
  
   vk_plugins.init();
   addEvent(document, 'mouseup', vkOnDocumentClick);
-  if (location.href.match('act=vkopt'))	vkShowSettings();
+  if (/act=vkopt/.test(location.href))	vkShowSettings();
   if (window.topMsg){
 	vkStManHook();
 	for (var key in StaticFiles)  if (key.indexOf('.js') != -1) vkInj(key); 
@@ -351,7 +351,7 @@ function ProcessAwayLink(node){
   if (href && href.indexOf('away.php?')!=-1){ 
 	var lnk=vkLinksUnescapeCyr(href).split('?to=')[1];
    if (!lnk) return;
-   var lnk=lnk.split('&h=')[0].split('&post=')[0];
+   lnk=lnk.split('&h=')[0].split('&post=')[0];
 	node.setAttribute('href',unescape(lnk).replace(/&h=[\da-z]{18}/i,''));
    //node.href=unescape(lnk).replace(/&h=[\da-z]{18}/i,'');
    /*
@@ -408,7 +408,7 @@ function vkGroupPage(){
 
 function vkGroupStatsBtn(){
       var p=ge('page_actions') || ge('unsubscribe');
-      if (p && !ge('vk_stats_list') && !(ge('page_actions') && ge('page_actions').innerHTML.match(/stats\?gid\=/))){
+      if (p && !ge('vk_stats_list') && !(ge('page_actions') && /stats\?gid=/.test(ge('page_actions').innerHTML))){
          var wklink=function(id){
             return vkCe('a',{id:id, onclick:"return nav.go(this, event)", href:"/stats?gid="+Math.abs(cur.oid)},IDL('Stats',1))
          };
@@ -524,8 +524,8 @@ function vkCheckGroupsAdmin(){
          }
       }
       if (gids.length>0){
-         var r="vk_adm_gr_"+remixmid();
-         vkSetVal(r,gids.join(','));
+         var k="vk_adm_gr_"+remixmid();
+         vkSetVal(k,gids.join(','));
       }
       //alert(gids.join('\n'));
    });
@@ -794,7 +794,7 @@ function vkPhChooseProcess(answer,url,q){
      var ref=q.act=="a_choose_photo_box"?geByClass('summary',div)[0]:geByClass('photos_choose_rows',div)[0];
      //*
      var p=geByClass('photos_choose_header_title',div)[0];
-     if (p && !p.innerHTML.match('choose_album')){
+     if (p && !/choose_album/.test(p.innerHTML)){
       p.innerHTML='';
       p.appendChild(vkCe('a',{"class":'fl_l_',href:'#',onclick:'return vk_photos.choose_album();'},IDL('mPhM',1)));
       console.log(q);
@@ -840,7 +840,7 @@ function vkVidChooseProcess(answer,url,q){
   var ref=geByClass('summary',div)[0] || geByClass('search_bar',div)[0] || geByClass('choose_search_cont',div)[0];
    
    var p=geByClass('choose_close',div)[0];
-   if (p && !p.innerHTML.match('choose_album')){
+   if (p && !/choose_album/.test(p.innerHTML)){
          p.insertBefore(vkCe('span',{"class":'divide'},'|'),p.firstChild);
          p.insertBefore(vkCe('a',{"class":'',href:'#',onclick:'return vk_videos.choose_album();'},IDL('mPhM',1)),p.firstChild);
          //console.log(q);
@@ -884,7 +884,7 @@ function vkAudioChooseProcess(answer,url,q){
   var ref=geByClass('summary',div)[0] || geByClass('search_bar',div)[0];
    
    var p=geByClass('choose_close',div)[0];
-   if (p && !p.innerHTML.match('choose_album')){
+   if (p && !/choose_album/.test(p.innerHTML)){
          p.insertBefore(vkCe('span',{"class":'divide'},'|'),p.firstChild);
          p.insertBefore(vkCe('a',{"class":'',href:'#',onclick:'return vk_audio.choose_album();'},IDL('mPhM',1)),p.firstChild);
          //console.log(q);
@@ -1272,7 +1272,7 @@ vk_im={
             var a=vkCe('a',{'onclick':'vk_im.attach_wall();','class':'add_media_item','style':"background-image: url('/images/icons/attach_icons.png'); background-position: 3px -130px;"},'<nobr>'+IDL('WallPost')+'</nobr>');
             p.appendChild(a);
             
-            var a=vkCe('a',{id:id,'style':'border-top:1px solid #DDD;'},html);
+            a=vkCe('a',{id:id,'style':'border-top:1px solid #DDD;'},html);
             p.appendChild(a);
 
          }
@@ -1427,7 +1427,7 @@ vk_im={
          } else {
            var rCont = false;
          }
-         el = rCont;
+         var el = rCont;
          while(el && el != editable) {
            el = el.parentNode;
          }

--- a/source/vk_media.js
+++ b/source/vk_media.js
@@ -852,7 +852,7 @@ var vk_photos = {
 };
 
 function vkPVPhotoMover(show_selector){
-   if (!show_selector && cur.pvCurPhoto && (cur.pvCurPhoto.actions || {}).edit && ge('pv_album_name') && !ge('pv_album_name').innerHTML.match('vkPVPhotoMover') && trim(ge('pv_album_name').innerHTML)!="" ){
+   if (!show_selector && cur.pvCurPhoto && (cur.pvCurPhoto.actions || {}).edit && ge('pv_album_name') && !/vkPVPhotoMover/.test(ge('pv_album_name').innerHTML) && trim(ge('pv_album_name').innerHTML)!="" ){
       ge('pv_album_name').innerHTML= '<div id="vk_ph_album_info">'+
                                     ge('pv_album_name').innerHTML+
                                     '<div class="fl_r vk_edit_ico" onclick="return vkPVPhotoMover(true);"> </div>'+
@@ -2956,7 +2956,7 @@ vk_audio={
      
      if ((node || ge('content')).innerHTML.indexOf('play_new')==-1) return;
      var smartlink=(getSet(1) == 'y');
-     var download=(getSet(0) == 'y')?1:0;
+     var download=(getSet(0) == 'y');
      //var clean_trash=getSet(94) == 'y';
      if (!download && getSet(43) != 'y') return;
      var SearchLink=true;
@@ -2978,7 +2978,6 @@ vk_audio={
             //if (clean_trash) vk_audio.process_node(anode);
              var el=geByClass("duration",anode )[0];
              var spans=el.parentNode.getElementsByTagName('span');
-             var span_title=null;
              var span_title=geByClass('title',anode )[0];
              if (window.nav && nav.objLoc[0]=='search' && !span_title){
                 for (var x=0; x<spans.length;x++)
@@ -3004,14 +3003,14 @@ vk_audio={
      }   
    },
    thread_count:0,
-   get_size:function(id,el,without_tip){
+   get_size:function(id,_el,without_tip){
       if (!without_tip) 
-         vkShowAddAudioTip(el,id);
+         vkShowAddAudioTip(_el,id);
       if (vk_audio.thread_count>=AUDIO_INFO_LOAD_THREADS_COUNT){
          var t = setInterval(function(){
             if (vk_audio.thread_count<AUDIO_INFO_LOAD_THREADS_COUNT){
                clearInterval(t);
-               vk_audio.get_size(id,el,without_tip);
+               vk_audio.get_size(id,_el,without_tip);
             }
          },50);
          return;
@@ -3442,7 +3441,7 @@ function vkCleanAudios(){
 	vkAlertBox(IDL('DelAudios'),'<b><a href="/'+owner+'">'+owner+'</a></b><br>'+IDL('DelAllAutiosConfirm'),run,true);
 }
 vkAudioEd = {
-   Delete:function(id,aid,el){
+   Delete:function(id,aid,_el){
     var el = ge('audio' + aid);
     var h = getSize(geByClass1('play_btn', el))[1];
     stManager.add(['audio_edit.js']);
@@ -3927,8 +3926,7 @@ vkLastFM={
       fm.token=localStorage['lastfm_token'];
       fm.username=localStorage['lastfm_username'];
       fm.session_key=localStorage['lastfm_session_key'];
-      fm.enable_scrobbling=parseInt(localStorage['lastfm_enable_scrobbling']);
-      if (isNaN(fm.enable_scrobbling)) fm.enable_scrobbling=0;
+      fm.enable_scrobbling=parseInt(localStorage['lastfm_enable_scrobbling']) || false;
       function LastFM(options){
          var apiKey=options.apiKey||'';
          var apiSecret=options.apiSecret||'';
@@ -4268,7 +4266,7 @@ vkLastFM={
       if (fm.enable_scrobbling){
          fm.enable_scrobbling=0;
       }*/
-      fm.enable_scrobbling=fm.enable_scrobbling?0:1;
+      fm.enable_scrobbling=!fm.enable_scrobbling;
       var els=geByClass('vk_lastfm_icon');
       for (var i=0; i<els.length;i++){
          var el=els[i];//ge('vk_lastfm_icon');


### PR DESCRIPTION
- если нужно проверить строку на соответствие регулярному выражению, надо использовать не .match(), а .test(). А у match() аргумент - регулярное выражение, а не строка.
- убрано переопределение переменных. `var a = smth; var a = othr;` - это плохо.
- toGMTString() заменена на более правильную toUTCString()
- вынесена одна повторяющаяся строка из if-else
- другие мелкие правки, повышающие корректность кода
