### PR TITLE
Нормализация возвращаемых значений

### DIFF
--- a/source/vk_face.js
+++ b/source/vk_face.js
@@ -867,7 +867,7 @@ vk_menu={
    },
    check_link:function(link){
       link=trim(link);
-      if (link=='') return;
+      if (link=='') return '';
       if (/^[a-z0-9_-]+\.[a-z]{2,7}(\/|$)/.test(link)) link='http://'+link;
       return  link;
    },

--- a/source/vk_lib.js
+++ b/source/vk_lib.js
@@ -1288,7 +1288,7 @@ vk_hor_slider={
     addEvent(document, selectEvent, cancelEvent);
     setStyle(bodyNode, 'cursor', 'pointer');
     setStyle(scale, 'cursor', 'pointer');
-    return false;
+    return;
   },
   sliderSelectChanged: function (id) {
     var percent = ge(id+'_select').value;
@@ -1431,7 +1431,7 @@ vk_v_slider={
     addEvent(document, selectEvent, cancelEvent);
     setStyle(bodyNode, 'cursor', 'pointer');
     setStyle(scale, 'cursor', 'pointer');
-    return false;
+    return;
   },
   sliderSelectChanged: function (id) {
     var percent = ge(id+'_select').value;

--- a/source/vk_main.js
+++ b/source/vk_main.js
@@ -2339,7 +2339,7 @@ function vkTopicTooltip(el,gid,topic,post,type){
 
 function vkTopicSubscribe(add_link){
 	if (add_link){
-		if (ge('vksubscribetopic')) return;
+		if (ge('vksubscribetopic')) return false;
 		if (nav.objLoc[0].indexOf('topic-')!=-1){
 			 var divider=(ge('privacy_edit_topic_action') && ge('privacy_edit_topic_action').parentNode && isVisible(ge('privacy_edit_topic_action').parentNode))?'<span class="divide">|</span>':'';
 			 geByClass('t0')[0].appendChild(vkCe('li',{"class":"t_r"},'<a href="#" id="vksubscribetopic" onclick="return vkTopicSubscribe();">'+IDL('addtop')+'</a>'+divider))

--- a/source/vk_media.js
+++ b/source/vk_media.js
@@ -510,7 +510,7 @@ var vk_photos = {
       var p=geByTag('body')[0];
       if (apply){
          if (getSet(82)=='y') addClass(p,'vk_full_thumbs_photos');
-         return;
+         return false;
       }
       setCfg(82,hasClass(p,'vk_full_thumbs_photos')?'n':'y');
       toggleClass(p,'vk_full_thumbs_photos');
@@ -863,7 +863,7 @@ function vkPVPhotoMover(show_selector){
    var a=(cur.pvCurPhoto.album || "").match(/album(-?\d+)_(\d+)/);
    if (!a){
       alert('album detect error');
-      return;
+      return false;
    }
    var oid=parseInt(a[1]);
    var aid=parseInt(a[2]);
@@ -1553,7 +1553,7 @@ function vkAlbumAdminItems(){
 }
 function vkPVAdminItems(data){
 	//alert(print_r(data));
-   if (!(data ||{}).author) return;
+   if (!(data ||{}).author) return '';
    //console.log(data);
 	var user=(data.author.split('href="')[1] || "").split('"')[0];
 	return (user && user!='' && ge('photos_container') && /album(-?\d+)_(\d+)/.test(cur.moreFrom || ''))?'<a href="#" onclick="photoview.hide(); vkGetPhotoByUser(\''+user+'\'); return false;">'+IDL('paAllUserPhotos')+'<span id="vkphloader" style="display:none"><img src="/images/upload.gif"></span></a>':'';
@@ -4169,7 +4169,7 @@ vkLastFM={
    },
    audio_info:function(){
       var fm=vkLastFM;
-      if (!(window.audioPlayer && audioPlayer.lastSong)) return;
+      if (!(window.audioPlayer && audioPlayer.lastSong)) return {};
       var a = audioPlayer.lastSong || [];
       return {
          title    :fm.clean(a[6]),
@@ -5817,7 +5817,7 @@ vk_vid_down={
          var map=(/*obj.adaptive_fmts ||*/obj.fmt_url_map || obj.url_encoded_fmt_stream_map);
          if (!map) {
             callback([]);
-            return [];
+            return;
          }
          /*
          var params={
@@ -5845,7 +5845,7 @@ vk_vid_down={
       });
    },
    vkYTVideoLinks: function(link){
-      if (String(link).indexOf('youtube.com')==-1) return;
+      if (String(link).indexOf('youtube.com')==-1) return '';
       var vid=String(link).split('?')[0].split('/').pop();
       vk_vid_down.vkGetYoutubeLinks(vid,function(r){
          //alert(JSON.Str(r));
@@ -5895,7 +5895,7 @@ vk_vid_down={
       }); 
    },
    vkVimeoVideoLinks: function(link){
-      if (String(link).indexOf('vimeo.com')==-1) return;
+      if (String(link).indexOf('vimeo.com')==-1) return '';
       var vid=String(link).split('?')[0].split('/').pop();
       vk_vid_down.vkGetVimeoLinks(vid,function(r){
          if (!r) return;

--- a/source/vk_settings.js
+++ b/source/vk_settings.js
@@ -804,7 +804,7 @@ vk_settings = {
        for (var i=0;i<setts.length;i++){
          var txt=(setts[i].text|| '').toUpperCase()+' '+(setts[i].header|| '').toUpperCase();
          s=s.toUpperCase();
-         if ( txt.indexOf(s)>-1 || s.test(txt)){// TopSearch.parseLatKeys(s)
+         if ( txt.indexOf(s)>-1 || txt.search(s)>-1){// TopSearch.parseLatKeys(s)
             sets.push(setts[i]);
          }
        }   

--- a/source/vk_users.js
+++ b/source/vk_users.js
@@ -1620,7 +1620,6 @@ function vkFavUsersList(add_button){
       p.innerHTML='<div id="vk_fav_users_cont" style="padding:10px;">'+html+'</div>';
       vkProcessNode(p);
    });
-   return false;
 }
 
 ////


### PR DESCRIPTION
Много функций возвращают в разных случаях разные типы, либо вообще ничего не возвращают. Лучше бы для каждой функции было заранее известно, какой тип она вернет и вернет ли вообще. В данной ветке кое-что поправлено, но оставлены без изменений функции типа

```
func(ret){
    if(ret) return ... ;
....
}
```

потому что во всех случаях их использования баги не возможны. Правда, при написании нового кода, используя эти функции, надо будет осторожно следить за вернувшимся типом. 
