### PR TITLE
Чистка имен файлов vkCleanFileName для Wget ссылок.

### DIFF
--- a/source/vk_media.js
+++ b/source/vk_media.js
@@ -5970,7 +5970,7 @@ vk_au_down={
 
             links.push(itm.url+(itm.url.indexOf('?')>0?'&/':'?/')+vkEncodeFileName(vkCleanFileName(itm.artist+" - "+itm.title))+".mp3");
 
-            wget_links.push('wget "'+itm.url+'" -O "'+winToUtf(itm.artist+" - "+itm.title).replace(/"/g,'\\"')+'.mp3"');
+            wget_links.push('wget "'+itm.url+'" -O "'+winToUtf(vkCleanFileName(itm.artist+" - "+itm.title)).replace(/"/g,'\\"')+'.mp3"');
 			
 			metalinklist.push('<file name="'+winToUtf(vkCleanFileName(itm.artist+" - "+itm.title))+'.mp3'+'">'
 								+'<resources><url type="http" preference="100">'+itm.url+'</url></resources>'


### PR DESCRIPTION
Добавление стандартной процедуры зачистки от нечитаемых или непраильно обрабатываемых символов для Wget ссылок.
Как показала практика такая чистка необходима особенно и для Wget ссылок. (К примеру. столкнулся кучу раз с проблемой, что не отрабатывается двоеточие ":" и скачивание не начинается)