### PR TITLE
Оптимизация работы с настройками

### DIFF
--- a/source/vk_lib.js
+++ b/source/vk_lib.js
@@ -651,42 +651,33 @@ var vkMozExtension = {
 	}
 	
 	function getSet(num,type) {
-	  var sett=vkgetCookie('remixbit');
-	  if (!sett) {
-		vksetCookie('remixbit',DefSetBits);
-		sett=DefSetBits;
-	  }
-	  
 	  /*if (!SettBit){
 	  if (!vkgetCookie('remixbit')) return null;}*/
-	  if (!SettBit) SettBit=vkgetCookie('remixbit');
-	  if (!type || type==null) type=0;
-	  if (num=='-')	return (SettBit.split('-')[type] || DefSetBits.split('-')[type]);
-	  
+      if (!SettBit) {
+          SettBit = vkgetCookie('remixbit');
+          if (!SettBit)
+              vksetCookie('remixbit', DefSetBits);
+      }
+	  if (!type) type=0;
+	  if (num=='-')	return SettBit.split('-')[type];
 	  
 	  
 	  var bit=SettBit.split('-')[type].charAt(num);
-	  if (!bit) bit=DefSetBits.split('-')[type].charAt(num);
 	  if (!bit) return 'n';
 	  else return bit;
 	}
 
-	function setSet(num,type,setting) {
+	function setSet(num,val,setting) {
 	if (!setting) setting=0;
 	var settings=vkgetCookie('remixbit').split('-');
-	if (num=='-') settings[setting]=type;
-	else settings[setting][num]=type;
+	if (num=='-') settings[setting]=val;
+	else settings[setting][num]=val;
 	SettBit = settings.join('-');
 	vksetCookie('remixbit',SettBit);
 	}
 
-	function setCfg(num,type) {
-	var allsett=vkgetCookie('remixbit').split('-');
-	var sett=allsett[0].split('');
-	sett[num]=type;
-	allsett[0]=sett.join('');
-	SettBit = allsett.join('-');//settings.allsett('-');
-	vksetCookie('remixbit',SettBit);
+	function setCfg(num,val) {
+	    setSet(num,val,0);
 	}
 
 	function vkRand(){return Math.round((Math.random() * (100000000 - 1)));}

--- a/source/vk_lib.js
+++ b/source/vk_lib.js
@@ -626,7 +626,7 @@ var vkMozExtension = {
 
 	function vkgetCookie(name,temp){
 	  if (name=='remixbit' && SettBit && !temp) return SettBit;
-	  if (name=='remixmid') { if (temp) return false; else { var tmp=remixmid(); return tmp; } }
+	  if (name=='remixmid') { var tmp=remixmid(); if (tmp) return tmp; }
 	  if (vkLocalStoreReady() && (SetsOnLocalStore[name] || /api\d+_[a-z]+/.test(name))){
 		var val=vkGetVal(name);
 		if (val) return val;
@@ -656,14 +656,17 @@ var vkMozExtension = {
       if (!SettBit) {
           SettBit = vkgetCookie('remixbit');
           if (!SettBit)
-              vksetCookie('remixbit', DefSetBits);
+              vksetCookie('remixbit', DefSetBits);  // vksetCookie изменяет SettBit, если имя 'remixbit'
       }
 	  if (!type) type=0;
 	  if (num=='-')	return SettBit.split('-')[type];
 	  
 	  
 	  var bit=SettBit.split('-')[type].charAt(num);
-	  if (!bit) return 'n';
+	  if (!bit) {
+	    bit=DefSetBits.split('-')[type].charAt(num);
+	    if (!bit) return 'n';
+      }
 	  else return bit;
 	}
 


### PR DESCRIPTION
Функции работы с настройками - одни из самых вызываемых (особенно getSet), но я нашел несколько ошибок оптимизации:

в функции getSet:
 1. переменная sett ни для чего не используется, кроме проверки существования куки.
 1. vkgetCookie вызывается излишнее число раз
 1. лишняя проверка type==null т.к. !type уже покрывает случай type==null
 1. избыточный код из-за различания текущих настроек и настроек по умолчанию в случае, когда они совпадают.

а также:
* в функции setSet и setCfg переменная type неправильно названа. На работу никак не влияет, но путает читателя, т.к. передает неправильный смысл.
* setCfg дублирует функционал setSet

И мне кажется, что хранить настройки в глобальной переменной SettBit лучше бы в виде массива, в уже разделенном виде, чтобы по всему коду не было вызовов split(), которые довольно медленные. (а они происходят 161 раз при каждом переходе по страницам).  Строкой есть смысл хранить только в куках (т.к. по-другому никак). Я хотел реализовать эту идею, но увидел в коде использование vkgetCookie и vksetCookie вместо вызова getSet и setSet - я мог бы это тоже исправить, но мне непонятен аргумент temp в функции vkgetCookie. На первый взгляд он там не нужен, но написано так, как будто без этого никак. Прошу пояснить.