### PR TITLE
Дополнение к #88 (настройки)

### DIFF
--- a/source/vk_lib.js
+++ b/source/vk_lib.js
@@ -672,7 +672,7 @@ var vkMozExtension = {
 	if (!setting) setting=0;
 	var settings=vkgetCookie('remixbit').split('-');
 	if (num=='-') settings[setting]=val;
-	else settings[setting][num]=val;
+	else settings[setting] = settings[setting].replace(new RegExp('^(.{'+num+'}).'), '$1'+val);
 	SettBit = settings.join('-');
 	vksetCookie('remixbit',SettBit);
 	}


### PR DESCRIPTION
Заметил, что после моего коммита из #88 перестало сохраняться состояние галочки "фильтрация". Это из-за того, что setCfg теперь вызывает setSet (я подумал, что код дублируется), а в setSet была ошибка: нельзя изменять символ строки по номеру, обратившись в стиле массива:
`str[i]='c'; // str не меняется`
и видимо до этого всё работало, потому что setSet не использовалась для remixbit настроек. Но так как в ней предусматривалось такое использование, я считаю что нужно исправить и использовать её для изменения всех видов настроек. В том числе в функции vkSwitchSet.