### PR TITLE
Дополнение к #75 (списки новостей)

### DIFF
--- a/source/vk_page.js
+++ b/source/vk_page.js
@@ -3417,7 +3417,7 @@ vk_feed={
         var input = geByClass('olist_filter', box.tabContent)[0];    // поле ввода "Быстрый поиск"
         if (input) {
             input.onkeyup = vk_feed.input_handler;
-            input.onfocus = function () {   // Подсказка о действии клавиши Enter
+            input.onclick = function () {   // Подсказка о действии клавиши Enter
                 vkSettInfo(input, IDL('EnterToSearch'));
             }
         }


### PR DESCRIPTION
Исправлен небольшой косметический баг: когда открываем окно редактирования списка новостей, подсказка о нажатии клавиши Enter сразу висит, и не убирется, пока по ней не проведешь мышкой или не сделаешь какое-нибудь другое действие. То есть если просто открыть и закрыть это окно, подсказка не уберется и будет висеть вечно, до тех пор, пока снова не откроешь это окно  и не проведешь мышкой над подсказкой. 
Поэтому подсказка теперь выводится только при нажатии мышкой на поле поиска. Думаю, этого будет достаточно.