### PR TITLE
Настройка хотфиксов

### DIFF
--- a/source/vk_main.js
+++ b/source/vk_main.js
@@ -288,7 +288,7 @@ function VkOptMainInit(){
   vkFaveOnlineChecker();
   vk_audio_player.init();
   vkMoneyBoxAddHide();
-  vkCheckUpdates();
+  if (ENABLE_HOTFIX) vkCheckUpdates();
   setTimeout(vkFriendsCheckRun,2000);
   window.vk_vid_down &&  setTimeout(vk_vid_down.vkVidLinks,0);
   if (vkgetCookie('IDFriendsUpd') && (vkgetCookie('IDFriendsUpd') != '_')) {	vkShowFriendsUpd();  }

--- a/source/vkopt.js
+++ b/source/vkopt.js
@@ -59,6 +59,7 @@ var AUDIO_INFO_SHOW_BITRATE=true;
 var AUDIO_DOWNLOAD_POSTFIX=false;
 var FEEDFILTER_DEBUG=false;
 var SHOW_OID_IN_TITLES=false;
+var ENABLE_HOTFIX=true;
 
 
 var VKOPT_CFG_LIST=[
@@ -86,6 +87,7 @@ var VKOPT_CFG_LIST=[
          'AUDIO_DOWNLOAD_POSTFIX',
          'FEEDFILTER_DEBUG',
          'SHOW_OID_IN_TITLES'
+         , 'ENABLE_HOTFIX'
 ];
 
 var vkNewSettings=[98,99,100,79]; //"new" label on settings item


### PR DESCRIPTION
Добавлена экстра-настройка, позволяющая отключить скачивание хотфиксов.
Не только для параноиков, но и для тех, кто сидит на бете.