### PR TITLE
Исправление работы extra-настрек

### DIFF
--- a/source/vk_settings.js
+++ b/source/vk_settings.js
@@ -797,7 +797,7 @@ vk_settings = {
       var orig={};
       for(var i=0; i<VKOPT_CFG_LIST.length; i++){
          orig[VKOPT_CFG_LIST[i]] = window[VKOPT_CFG_LIST[i]];
-         if (cfg[VKOPT_CFG_LIST[i]]==='' || cfg[VKOPT_CFG_LIST[i]]==null) continue;
+         if (cfg[VKOPT_CFG_LIST[i]]==null) continue;
          window[VKOPT_CFG_LIST[i]] = cfg[VKOPT_CFG_LIST[i]];
       }
       if (!window.VKOPT_CFG_LIST_ORIG) window.VKOPT_CFG_LIST_ORIG=orig;


### PR DESCRIPTION
Исправлена неправильная работа extra-настроек.
Если по умолчанию настройка true, а пользователь её выключает, то тогда она остается выключенной только до перезагрузки страницы. Функция isChecked возвращает пустую строку в случае, если пользователь снял галочку, а VkOpt считает, что если значение настройки - пустая строка, то это какая-то ошибка и это не надо принимать во внимание. И значение настройки остается по умолчанию, т.е. true