### PR TITLE
Показывать всплывающий аватар справа, если под курсором

### DIFF
--- a/source/vk_users.js
+++ b/source/vk_users.js
@@ -618,7 +618,7 @@ function vkShowProfile(el,html,uid,right){
       top=(top<getScrollTop())?getScrollTop():top;
       
       var left=xy[0] - pb.offsetWidth + 5;
-      if (left<0) left=0;
+      if (left < 0) right = true;
       //alert(getScrollTop()+"\n"+getScrH()+"\n"+height+"\n"+(xy[1]+el.offsetHeight)+"\n"+el.offsetHeight);
       if (right) {
         p.style.left = (xy[0] + el.offsetWidth + 10) + "px";


### PR DESCRIPTION
Чувак на форуме [пишет](http://vkopt.net/forum/showthread.php?p=68083#post68083):
> Функция "Всплывание фото/информации при наведении на маленькие аватары" глючит. Если наведёшь курсор на аватар, а всплывающая увеличенная картинка в этот момент окажется под курсором, то она будет мигать, особенно это заметно когда открываешь подробности на картинке и наводишь курсором на аватар находящимся в левом части экрана:

У меня тоже такое иногда бывает. Предлагаю решить проблему, показывая всплывашку справа в случае если всплывашка под курсором, потому что тогда будет вышеописанное мигание.