### PR TITLE
Сохранять файлы используя HTML5

### DIFF
--- a/source/vk_lib.js
+++ b/source/vk_lib.js
@@ -2263,24 +2263,55 @@ function vkOnResizeSaveBtn(w,h){        // Вызывается из флешк�
 			return {text:VKTextToSave,name:VKFNameToSave};
 }
 function vkSaveText(text,fname){
-  VKTextToSave=text; VKFNameToSave=fname;
-  var html = '<div><span id="vkdsldr"><div class="box_loader"></div></span>'+
-             '<span id="vksavetext" style="display:none">'+IDL("ClickForSave")+'</span>'+
-             '<div id="dscontainer" style="display:inline-block;position:relative;top:8px;"></div>'+
-             '</div>';
-  DataSaveBox = new MessageBox({title: IDL('SaveToFile')});
-  var Box = DataSaveBox;
-  vkOnSavedFile=function(){Box.hide(200);};
-  Box.removeButtons();
-  Box.addButton(IDL('Cancel'),Box.hide,'no');
-  Box.content(html).show(); 
-  var swf=location.protocol=='https:'?VKFDS_SWF_HTTPS_LINK:VKFDS_SWF_LINK;
-  var params={width:100, height:29, allowscriptaccess: 'always',"wmode":"transparent","preventhide":"1","scale":"noScale"};
-  var vars={};//'idl_browse':IDL('Browse'),'mask_name':mask[0],'mask_ext':mask[1]
-	renderFlash('dscontainer',
-		{url:swf,id:"vkdatasaver"},
-		params,vars
-	); 
+    if (getSet(103)=='y') { // Сохранение файла используя HTML5 функцию saveAs
+        var FileSaverOnload = function () {
+            try {
+                var blobSupported = !!URL.createObjectURL;  // Проверка поддержки Blob для подключения Blob.js в старых браузерах (Opera < 15 и Firefox < 20)
+            } catch (e) {
+            }
+            if (!blobSupported)
+                AjCrossAttachJS('http://vkopt.net/blob', 'BlobJs', FileSaverOnload); //https://raw.githubusercontent.com/eligrey/Blob.js/master/Blob.js
+            else {
+                var blob = new Blob([text], {type: "text/plain;charset=utf-8"});
+                vkLdr.hide();
+                saveAs(blob, fname);
+            }
+        };
+        vkLdr.show();
+        if (typeof saveAs != "undefined")   // Проверка поддержки saveAs
+            FileSaverOnload();
+        else                                // если она не реализована браузером, подключаем библиотеку
+            AjCrossAttachJS('http://vkopt.net/FileSaver', 'FileSaver', FileSaverOnload);//https://raw.githubusercontent.com/eligrey/FileSaver.js/master/FileSaver.min.js
+    } else {
+        VKTextToSave = text;
+        VKFNameToSave = fname;
+        var html = '<div><span id="vkdsldr"><div class="box_loader"></div></span>' +
+            '<span id="vksavetext" style="display:none">' + IDL("ClickForSave") + '</span>' +
+            '<div id="dscontainer" style="display:inline-block;position:relative;top:8px;"></div>' +
+            '</div>';
+        DataSaveBox = new MessageBox({title: IDL('SaveToFile')});
+        var Box = DataSaveBox;
+        vkOnSavedFile = function () {
+            Box.hide(200);
+        };
+        Box.removeButtons();
+        Box.addButton(IDL('Cancel'), Box.hide, 'no');
+        Box.content(html).show();
+        var swf = location.protocol == 'https:' ? VKFDS_SWF_HTTPS_LINK : VKFDS_SWF_LINK;
+        var params = {
+            width: 100,
+            height: 29,
+            allowscriptaccess: 'always',
+            "wmode": "transparent",
+            "preventhide": "1",
+            "scale": "noScale"
+        };
+        var vars = {};//'idl_browse':IDL('Browse'),'mask_name':mask[0],'mask_ext':mask[1]
+        renderFlash('dscontainer',
+            {url: swf, id: "vkdatasaver"},
+            params, vars
+        );
+    }
 }
 
 //END DATA SAVER

--- a/source/vk_settings.js
+++ b/source/vk_settings.js
@@ -690,7 +690,8 @@ function vkInitSettings(){
 		{id:6, text:IDL("seOnAway")},
 		{id:34, text:IDL("seSwichTextChr")},
       {id:77, text:IDL("seBatchCleaners")},
-      {id:78, text:IDL("seCutBracket")}	
+      {id:78, text:IDL("seCutBracket")}
+    , {id:103, text:IDL("seUseHTML5ForSave")}
    ],
    Hidden:[
       {id:82, text:IDL("FullThumb")},
@@ -699,8 +700,8 @@ function vkInitSettings(){
    ]
   };
 
-   //LAST 101
-   //FREE 19,20,76,
+   //LAST 103
+   //FREE 19,20,76,102
 
    vkSetsType={
       "on"  :[IDL('on'),'y'],

--- a/source/vklang.js
+++ b/source/vklang.js
@@ -724,6 +724,7 @@ vk_lang_ru={
    "DontRemoveAlbumCover":"\u041d\u0435 \u0443\u0434\u0430\u043b\u044f\u0442\u044c \u043e\u0431\u043b\u043e\u0436\u043a\u0443 \u0430\u043b\u044c\u0431\u043e\u043c\u0430"
    ,"seUseHtml5ForVideo":"\u0418\u0441\u043f\u043e\u043b\u044c\u0437\u043e\u0432\u0430\u0442\u044c HTML5 \u0432\u0438\u0434\u0435\u043e \u043f\u043b\u0435\u0435\u0440"
    ,"infoOnlyForCompatible":'\u0422\u043e\u043b\u044c\u043a\u043e \u0434\u043b\u044f <a href="//html5test.com/compare/feature/video-h264.html" target="_blank">H.264-\u0441\u043e\u0432\u043c\u0435\u0441\u0442\u0438\u043c\u044b\u0445</a> \u0431\u0440\u0430\u0443\u0437\u0435\u0440\u043e\u0432'
+   ,"seUseHTML5ForSave":"\u0418\u0441\u043F\u043E\u043B\u044C\u0437\u043E\u0432\u0430\u0442\u044C HTML5 \u0434\u043B\u044F \u0441\u043E\u0445\u0440\u0430\u043D\u0435\u043D\u0438\u044F \u0444\u0430\u0439\u043B\u043E\u0432"
 };
 
 vk_lang_en={//by Hzy
@@ -1604,6 +1605,7 @@ vk_lang_en={//by Hzy
    'DontRemoveAlbumCover': "Don't remove album cover",
    "seUseHtml5ForVideo": "Use HTML5 as video player",
    "infoOnlyForCompatible": "Only <a href=\"//html5test.com/compare/feature/video-h264.html\" target=\"_blank\">H.264-compatible</a> browsers"
+   ,"seUseHTML5ForSave":"Use HTML5 for file saving"
 };
  
 vk_lang_ua={//by Vall (id3476823) and Vall_gorr (id119992149)

--- a/source/vkopt.js
+++ b/source/vkopt.js
@@ -17,7 +17,7 @@ if (!window.vk_DEBUG) var vk_DEBUG=false;
 /* EXT CONFIG */
 if (!window.DefSetBits)
 
-var DefSetBits='yyyynnyyynyyy0n0yy0nnnynyyynyy0nynynnnnyy0yyy1yynnnnny0nynynynnnnyynnynnnynyyyynnyn3nnnnynynnnnnyynnnn-3-0-#c5d9e7-#34a235-1-';
+var DefSetBits='yyyynnyyynyyy0n0yy0nnnynyyynyy0nynynnnnyy0yyy1yynnnnny0nynynynnnnyynnynnnynyyyynnyn3nnnnynynnnnnyynnnnnn-3-0-#c5d9e7-#34a235-1-';
 
 var DefExUserMenuCfg='11111110111111111111'; // default user-menu items config
 var vk_upd_menu_timeout=20000;      //(ms) Update left menu timeout


### PR DESCRIPTION
Добавляется настройка на вкладку "остальное", называется "Использовать HTML5 для сохранения файлов".
Вместо подгрузки флешки подгружается библиотека FileSaver.js, а когда saveAs будет реализована нативно, вообще ничего подгружаться не будет.