### PR TITLE
Улучшение vkLdr

### DIFF
--- a/source/vk_lib.js
+++ b/source/vk_lib.js
@@ -2401,7 +2401,7 @@ vkLdr={
 	box:null,
 	show:function(){
 		vkLdr.box=new MessageBox({title:''});
-		vkLdr.box.setOptions({title: false, hideButtons: true,onHide:__bq.hideAll}).show(); 
+		vkLdr.box.setOptions({title: false, hideButtons: true,onHide:__bq.hideLast}).show();
 		hide(vkLdr.box.bodyNode); 
 		show(boxLoader);
 		boxRefreshCoords(boxLoader);	


### PR DESCRIPTION
Если `vkLdr.show()` вызывается при открытом каком-то всплывающем окне, то при `vkLdr.hide()` закрываются все окна, и еще остается черный прозрачный фон. Нужно `hideAll` поменять на `hideLast`