### PR TITLE
Принудительно использовать HTML5 аудио плеер

### DIFF
--- a/source/vk_media.js
+++ b/source/vk_media.js
@@ -3071,6 +3071,7 @@ vk_audio_player={
    inj:function(){
       if (getSet(75)=='y') vk_audio_player.gpCtrlsInit();
       Inj.Start('audioPlayer.scrollToTrack','if (!vk_audio_player.scroll_to_track_enabled) return;');
+      if (getSet(104)=='y') Inj.Before('audioPlayer.initPlayer','browser.flash','false && ');
    },  
    init:function(){
       if (getSet(85)=='y') vk_audio_player.scroll_to_track_enabled=false;

--- a/source/vk_settings.js
+++ b/source/vk_settings.js
@@ -594,6 +594,7 @@ function vkInitSettings(){
       {id:7,  text:IDL("seScroolPhoto")},
       {id:93, text:IDL("seAlbumPhotosExInfo"),info:'infoUseNetTrafic'}
       , {id:101, text:IDL("seUseHtml5ForVideo"),info:'infoOnlyForCompatible'}
+      , {id:104, text:IDL("seUseHtml5ForAudio")}
     ],
     Users:[
       {id:10, text:IDL("seExUserMenu")+'<br><a href="#" onclick="toggle(\'vkExUMenuCFG\'); return false;">[<b> '+IDL("Settings")+' </b>]</a>'+
@@ -699,8 +700,8 @@ function vkInitSettings(){
    ]
   };
 
-   //LAST 101
-   //FREE 19,20,76,
+   //LAST 104
+   //FREE 19,20,76,102,103
 
    vkSetsType={
       "on"  :[IDL('on'),'y'],

--- a/source/vklang.js
+++ b/source/vklang.js
@@ -724,6 +724,7 @@ vk_lang_ru={
    "DontRemoveAlbumCover":"\u041d\u0435 \u0443\u0434\u0430\u043b\u044f\u0442\u044c \u043e\u0431\u043b\u043e\u0436\u043a\u0443 \u0430\u043b\u044c\u0431\u043e\u043c\u0430"
    ,"seUseHtml5ForVideo":"\u0418\u0441\u043f\u043e\u043b\u044c\u0437\u043e\u0432\u0430\u0442\u044c HTML5 \u0432\u0438\u0434\u0435\u043e \u043f\u043b\u0435\u0435\u0440"
    ,"infoOnlyForCompatible":'\u0422\u043e\u043b\u044c\u043a\u043e \u0434\u043b\u044f <a href="//html5test.com/compare/feature/video-h264.html" target="_blank">H.264-\u0441\u043e\u0432\u043c\u0435\u0441\u0442\u0438\u043c\u044b\u0445</a> \u0431\u0440\u0430\u0443\u0437\u0435\u0440\u043e\u0432'
+   ,"seUseHtml5ForAudio":"\u0418\u0441\u043f\u043e\u043b\u044c\u0437\u043e\u0432\u0430\u0442\u044c HTML5 \u0430\u0443\u0434\u0438\u043e \u043f\u043b\u0435\u0435\u0440"
 };
 
 vk_lang_en={//by Hzy
@@ -1604,6 +1605,7 @@ vk_lang_en={//by Hzy
    'DontRemoveAlbumCover': "Don't remove album cover",
    "seUseHtml5ForVideo": "Use HTML5 as video player",
    "infoOnlyForCompatible": "Only <a href=\"//html5test.com/compare/feature/video-h264.html\" target=\"_blank\">H.264-compatible</a> browsers"
+  ,"seUseHtml5ForAudio":"Use HTML5 as audio player"
 };
  
 vk_lang_ua={//by Vall (id3476823) and Vall_gorr (id119992149)

--- a/source/vkopt.js
+++ b/source/vkopt.js
@@ -17,7 +17,7 @@ if (!window.vk_DEBUG) var vk_DEBUG=false;
 /* EXT CONFIG */
 if (!window.DefSetBits)
 
-var DefSetBits='yyyynnyyynyyy0n0yy0nnnynyyynyy0nynynnnnyy0yyy1yynnnnny0nynynynnnnyynnynnnynyyyynnyn3nnnnynynnnnnyynnnn-3-0-#c5d9e7-#34a235-1-';
+var DefSetBits='yyyynnyyynyyy0n0yy0nnnynyyynyy0nynynnnnyy0yyy1yynnnnny0nynynynnnnyynnynnnynyyyynnyn3nnnnynynnnnnyynnnnnnn-3-0-#c5d9e7-#34a235-1-';
 
 var DefExUserMenuCfg='11111110111111111111'; // default user-menu items config
 var vk_upd_menu_timeout=20000;      //(ms) Update left menu timeout


### PR DESCRIPTION
Сейчас HTML5 плеер используется для воспроизведения аудиозаписей только на компьютерах с Flash-плеером версии меньше 9 и на маках.
Новая настройка даёт возможность использовать HTML5 плеер принудительно.
![- 24 04 2015 - 15 01 46](https://cloud.githubusercontent.com/assets/2682026/7318545/b43e079a-ea95-11e4-9b57-f551e6e23c30.png)

_у меня, правда не сразу заработало - надо было обновить libav-tools и libavutil54_