### PR TITLE
Добавлена ссылка на альбом на last.fm

### DIFF
--- a/source/vk_media.js
+++ b/source/vk_media.js
@@ -4786,7 +4786,7 @@ function vkViewAlbumInfo(artist,track){
       if (data.act!='artist_info'){
          var year=(new Date(data.releasedate)).getFullYear();
          html=preview_album_info_tpl.replace(/%ALBUM%/g,IDL('Album'))
-                                    .replace(/%NAME%/g,data.name+(year?' ('+year+')':''))
+                                    .replace(/%NAME%/g,'<a href="'+data.url+'" target="_blank">'+data.name+(year?' ('+year+')':'')+'</a>')
                                     .replace(/%ARTIST%/g,data.artist)
                                     .replace(/%IMG%/g,data.image[1]['#text'] || '/images/question_c.gif')
                                     .replace(/%IMG2%/g,data.image[2]['#text'] || '/images/question_c.gif')


### PR DESCRIPTION
Когда в аудиозаписях справа подгружается инфа об альбоме, выводим не просто его название, а еще и ссылку на Last.fm
![- 28 04 2015 - 12 21 20](https://cloud.githubusercontent.com/assets/2682026/7366479/475f6bfa-eda1-11e4-81fe-a26a4adbdd3b.png)
