### PR TITLE
Кнопки быстрого перехода к постам

### DIFF
--- a/source/vk_main.js
+++ b/source/vk_main.js
@@ -362,6 +362,7 @@ function vkPublicPage(){
    vkUpdWallBtn();
    vk_groups.show_members_btn();
    vk_groups.show_oid();
+   vkScrollPosts('page_wall_posts');
 }
 /* EVENTS */
 function vkEventPage(){
@@ -386,6 +387,7 @@ function vkGroupPage(){
    vk_groups.show_members_btn();
    vk_groups.requests_block();
    vk_groups.show_oid();
+   vkScrollPosts('page_wall_posts');
 }
 
 function vkGroupStatsBtn(){

--- a/source/vk_settings.js
+++ b/source/vk_settings.js
@@ -676,6 +676,7 @@ function vkInitSettings(){
       {id:99, text:IDL("seSortByLikes")},
       {id:100, text:IDL("seTopicSearch")}
       //{id:64, text:IDL("seToTopOld")}
+     ,{id:19, text:IDL("seTurningPosts")}
     ],
 	Sounds:[
 	  {id:48, text:IDL("ReplaceVkSounds")}	
@@ -701,7 +702,7 @@ function vkInitSettings(){
   };
 
    //LAST 103
-   //FREE 19,20,76,102
+   //FREE 20,76,102
 
    vkSetsType={
       "on"  :[IDL('on'),'y'],

--- a/source/vklang.js
+++ b/source/vklang.js
@@ -725,6 +725,7 @@ vk_lang_ru={
    ,"seUseHtml5ForVideo":"\u0418\u0441\u043f\u043e\u043b\u044c\u0437\u043e\u0432\u0430\u0442\u044c HTML5 \u0432\u0438\u0434\u0435\u043e \u043f\u043b\u0435\u0435\u0440"
    ,"infoOnlyForCompatible":'\u0422\u043e\u043b\u044c\u043a\u043e \u0434\u043b\u044f <a href="//html5test.com/compare/feature/video-h264.html" target="_blank">H.264-\u0441\u043e\u0432\u043c\u0435\u0441\u0442\u0438\u043c\u044b\u0445</a> \u0431\u0440\u0430\u0443\u0437\u0435\u0440\u043e\u0432'
    ,"seUseHTML5ForSave":"\u0418\u0441\u043F\u043E\u043B\u044C\u0437\u043E\u0432\u0430\u0442\u044C HTML5 \u0434\u043B\u044F \u0441\u043E\u0445\u0440\u0430\u043D\u0435\u043D\u0438\u044F \u0444\u0430\u0439\u043B\u043E\u0432"
+   ,"seTurningPosts":"\u041a\u043d\u043e\u043f\u043a\u0438 \u043b\u0438\u0441\u0442\u0430\u043d\u0438\u044f \u043f\u043e\u0441\u0442\u043e\u0432"
 };
 
 vk_lang_en={//by Hzy
@@ -1606,6 +1607,7 @@ vk_lang_en={//by Hzy
    "seUseHtml5ForVideo": "Use HTML5 as video player",
    "infoOnlyForCompatible": "Only <a href=\"//html5test.com/compare/feature/video-h264.html\" target=\"_blank\">H.264-compatible</a> browsers"
    ,"seUseHTML5ForSave":"Use HTML5 for file saving"
+   ,"seTurningPosts":"Turning posts buttons"
 };
  
 vk_lang_ua={//by Vall (id3476823) and Vall_gorr (id119992149)


### PR DESCRIPTION
Есть такой сайт, [Пикабу](http://pikabu.ru). Там выкладываются интересные и развлекательные картинки. Мне нравится, как там сделан переход (прокрутка) от одного поста к другому - вверху справа есть кнопки "следующий" и "предыдущий", при нажатии на которые страница прокручивается так, что следующий (предыдущий) пост сразу оказываются под верхней границей окна браузера. Т.е. прокручивание колесиком мышки заменяется на один щелчок. А также эта функция срабатывает при нажатии на кнопки клавиатуры A (предыдущий) и D (следующий).
Я сделал, чтобы таким же образом можно было листать "новости" и стены групп, пабликов и профилей. Дизайн нагло украл у Пикабу, правда реализовал его через CSS, а не картинками.
Еще на Пикабу к клавиатуре привязаны другие действия, например на кнопки W и S привязаны "плюс" и "минус" текущему посту. В принципе можно и здесь такое сделать. Но так как это не относится к навигации, пока не сделал. (а надо ли?)
Настройка добавлена на вкладку "интерфейс".
Скрин:
![- 29 04 2015 - 16 50 51](https://cloud.githubusercontent.com/assets/2682026/7394070/0427c234-ee9a-11e4-9154-f629ed418f02.png)
PS. Не совсем уверен в названии настройки на английском языке. Да и на русском тоже.