### PR TITLE
Дополнение к #130: при наличии вверху отфильтрованных постов

### DIFF
--- a/source/vk_page.js
+++ b/source/vk_page.js
@@ -3518,7 +3518,7 @@ function vkScrollPosts(parent_id) {  // Добавление панельки с
         var previousPost = function () {
             var elem = ge(parent_id).firstElementChild;   // первый пост
             if (elem) {
-                while (elem && elem.getBoundingClientRect().top < -1 || elem.tagName != 'DIV')
+                while (elem && elem.getBoundingClientRect().top < -1 || elem.getBoundingClientRect().x==0)
                     elem = elem.nextElementSibling;
                 elem = elem.previousElementSibling;         // в этом месте elem был текущим постом, а стал предыдущим
                 if (elem) scrollToY(getXY(elem)[1], 100);
@@ -3541,6 +3541,7 @@ function vkScrollPosts(parent_id) {  // Добавление панельки с
         };
         next.onclick = nextPost;
 
+        removeEvent(document.body, 'keydown');
         addEvent(document.body, 'keydown', function(ev){    // биндим кнопки A и D на функции предыдущего и следующего поста
             if (document.activeElement == document.body) {  // Срабатывать только если пользователь сейчас не пишет текст
                 if (ev.keyCode == 65) previousPost();       // A


### PR DESCRIPTION
Я нашел баг в кнопках быстрого перехода к постам.
В случае, если включена фильтрация ленты новостей, и если присутствует отфильтрованный пост, и он находится выше, чем видимая область страницы, кнопка "предыдущий" не работает.
Потому что почему-то `getBoundingClientRect()` возвращает объект с нулями для невидимых элементов, хотя по-моему логичнее было бы возвращать null или объект с null-ами.

и еще добавлено удаление событий keydown перед добавлением. потому что при переходе с профиля в новости или с новостей на профиль новый обработчик не заменяет старый, а добавляется, причем при нажатии на клавиши отрабатывает только старый. Тоже мутная история, короче. Вообще лучше найти способ удаления только старого обработчика, а то вдруг там еще какие-то будут. Но пока и так сойдет.