### PR TITLE
Исправление стилей налезающего на поиск - поля для ввода  id аудио

### DIFF
--- a/source/vk_main.js
+++ b/source/vk_main.js
@@ -833,7 +833,7 @@ function vkVidChooseProcess(answer,q){
    } 
   
   if (ref){
-    var node=vkCe('div',{'style':"height: 25px; padding: 4px 20px; padding-left:0px; margin-top: 33px;","class":'vk_opa2 vk_idattach'},'\
+    var node=vkCe('div',{'style':"padding: 4px 20px; padding-left:0px; margin-top: 33px;","class":'vk_opa2 vk_idattach'},'\
     <div class="fl_l">'+IDL('EnterLinkToVideo')+':</div>\
       <span class="fl_l"><input id="vk_link_to_video" type="text"  style="width:215px" class="s_search text"></span>\
       <div id="vk_link_to_video_button" class="button_blue fl_r"  style="vertical-align: middle;"><button onclick="vkCheckVideoLinkToMedia();">'+IDL('OK')+'</button></div>\
@@ -877,7 +877,7 @@ function vkAudioChooseProcess(answer,q){
    }
   
   if (ref){
-    var node=vkCe('div',{'style':"height: 25px; padding: 4px 20px; padding-left:0px; margin-top: 33px;","class":'vk_opa2 vk_idattach'},'\
+    var node=vkCe('div',{'style':"padding: 4px 20px; padding-left:0px; margin-top: 33px;","class":'vk_opa2 vk_idattach'},'\
     <div class="fl_l" style="line-height:20px">'+IDL('EnterLinkToAudio')+':</div>\
       <span class="fl_l"><input id="vk_link_to_audio" type="text" style="width:190px"  class="s_search text"></span>\
       <div id="vk_link_to_audio_button" class="button_blue fl_r"  style="vertical-align: middle;"><button onclick="vkCheckAudioLinkToMedia();">'+IDL('OK')+'</button></div>\

--- a/source/vk_main.js
+++ b/source/vk_main.js
@@ -786,7 +786,7 @@ function vkPhChooseProcess(answer,q){
       }
      }//*/
      if (ref){
-       var node=vkCe('div',{"class":'ta_r vk_opa2','style':"height: 25px; padding-left:10px; padding-top:4px;"},'\
+       var node=vkCe('div',{"class":'ta_r vk_opa2','style':"padding-left:10px; padding-top:4px;"},'\
        <div class="fl_l">\
            '+IDL('EnterLinkToPhoto')+': \
          <span><input id="vk_link_to_photo" type="text"  style="width:230px" class="s_search text"></span>\


### PR DESCRIPTION
Из-за постоянного размера высоты в 25px поле для ввода id аудио может налезть на поле для поиска (в компактных стилях, vkfix например). Лучше пусть оно будет стандартного размера. В обычном режиме все нормально и без этого значения.
Налезает в компактном: 
![](http://savepic.org/7327940.png)
Обычный режим (без 25px высоты): 
![](http://savepic.org/7317700.png)