### PR TITLE
Исправление vkPopupAvatar

### DIFF
--- a/source/vk_users.js
+++ b/source/vk_users.js
@@ -564,7 +564,7 @@ function vkPopupAvatar(id,el,in_box){
             //LoadedProfiles[id]=html;
             box.hide();
             box=vkAlertBox('id'+uid,html);
-            box.setOptions({width:"455px",hideButtons:true, bodyStyle:'padding:0px;', onHide:__bq.hideAll});
+            box.setOptions({width:"455px",hideButtons:true, bodyStyle:'padding:0px;', onHide:__bq.hideLast});
          },true);
          
       }else  if (LoadedProfiles[id]){


### PR DESCRIPTION
Исправлена проблема, когда заходишь в группу, в раздел Участники, потом вызываешь юзер-меню,  потом жмёшь на галочку рядом с "Страница", и потом на крестик (закрыть). Закрываются все всплывашки, и остается черный фон, с которым ничего не сделать.
Ошибка аналогична #124 