### PR TITLE
Не показывать всплывающий профиль undefined

### DIFF
--- a/source/vk_users.js
+++ b/source/vk_users.js
@@ -549,7 +549,7 @@ allowShowPhotoTimer=setTimeout(null,null);
 cur_popup_idx=0;
 cur_popup_url=null;
 function vkPopupAvatar(id,el,in_box){
-    if (id==null) return;
+    if (id==null || id=='undefined') return;
     if (!window.LoadedProfiles) LoadedProfiles={};
     allowShowPhoto=true;
     if (cur_popup_url!=id)


### PR DESCRIPTION
Встречаются некоторые ссылки на vk.com, которые ведут не на профиль. Для таких ссылок всплывающий профиль показывает данные для профиля с коротким именем undefined. Я считаю, что для таких ссылок не надо показывать всплывающий профиль.
![2](https://cloud.githubusercontent.com/assets/2682026/8024071/4f5d2b6e-0d2f-11e5-8f38-6de9b00a5fb8.png)
