### PR TITLE
Функция массового скачивания вики-страниц

### DIFF
--- a/source/vk_lib.js
+++ b/source/vk_lib.js
@@ -2302,24 +2302,12 @@ function vkOnResizeSaveBtn(w,h){        // Вызывается из флешк�
 }
 function vkSaveText(text,fname){
     if (getSet(103)=='y') { // Сохранение файла используя HTML5 функцию saveAs
-        var FileSaverOnload = function () {
-            try {
-                var blobSupported = !!URL.createObjectURL;  // Проверка поддержки Blob для подключения Blob.js в старых браузерах (Opera < 15 и Firefox < 20)
-            } catch (e) {
-            }
-            if (!blobSupported)
-                AjCrossAttachJS('http://vkopt.net/blob', 'BlobJs', FileSaverOnload); //https://raw.githubusercontent.com/eligrey/Blob.js/master/Blob.js
-            else {
-                var blob = new Blob([text], {type: "text/plain;charset=utf-8"});
-                vkLdr.hide();
-                saveAs(blob, fname);
-            }
-        };
         vkLdr.show();
-        if (typeof saveAs != "undefined")   // Проверка поддержки saveAs
-            FileSaverOnload();
-        else                                // если она не реализована браузером, подключаем библиотеку
-            AjCrossAttachJS('http://vkopt.net/FileSaver', 'FileSaver', FileSaverOnload);//https://raw.githubusercontent.com/eligrey/FileSaver.js/master/FileSaver.min.js
+        FileSaverConnect(function() {
+            var blob = new Blob([text], {type: "text/plain;charset=utf-8"});
+            vkLdr.hide();
+            saveAs(blob, fname);
+        });
     } else {
         VKTextToSave = text;
         VKFNameToSave = fname;
@@ -2351,7 +2339,32 @@ function vkSaveText(text,fname){
         );
     }
 }
+// Подключение библиотеки FileSaver.js и последующее выполнение функции callback
+function FileSaverConnect(callback) {
+    var FileSaverOnload = function () {
+        try {
+            var blobSupported = !!URL.createObjectURL;  // Проверка поддержки Blob для подключения Blob.js в старых браузерах (Opera < 15 и Firefox < 20)
+        } catch (e) {}
+        if (!blobSupported)
+            AjCrossAttachJS('http://vkopt.net/blob', 'BlobJs', FileSaverOnload);
+        else
+            callback();
+    };
+    if (typeof saveAs != "undefined")   // Проверка поддержки saveAs
+        FileSaverOnload();
+    else                                // если она не реализована браузером, подключаем библиотеку
+        AjCrossAttachJS('http://vkopt.net/FileSaver', 'FileSaver', FileSaverOnload);
+}
 
+// Подключение библиотеки JsZip и последующее выполнение функции callback
+function JsZipConnect(callback) {
+    FileSaverConnect(function () {
+        if (typeof JSZip != "undefined")
+            callback();
+        else
+            AjCrossAttachJS('http://vkopt.net/jszip', 'JsZip', callback);
+    });
+}
 //END DATA SAVER
 
 // DATA LOADER

--- a/source/vk_main.js
+++ b/source/vk_main.js
@@ -488,13 +488,13 @@ function vkWikiDownload(oid) {
                             dataURL = canvas.toDataURL('image/jpeg');
                             this.onload = null;
                             this.src = dataURL;
-                            this.crossOrigin = '';
+                            this.removeAttribute('crossOrigin');
                             if (imgs_loaded == imgs_total)  // если это последняя загруженная картинка на странице, сохраняем страницу.
                                 flushPage(response.title, pid, el.innerHTML);
                         };
                         imgs[j].onerror = function () {
                             imgs_loaded++;
-                            this.crossOrigin = '';
+                            this.removeAttribute('crossOrigin');
                             if (imgs_loaded == imgs_total)  // не удалось загрузить картинку, однако она последняя; всё равно сохраняем страницу.
                                 flushPage(response.title, pid, el.innerHTML);
                         }

--- a/source/vk_media.js
+++ b/source/vk_media.js
@@ -1484,38 +1484,20 @@ function vkGetZipWithPhotos(oid, aid) {
             saveAs(content, "photos_" + vkCleanFileName((oid || '') + '_' + (aid || '')).substr(0, 250) + ".zip");
             div.innerHTML = ''; // очистить прогрессбар
         }
-    }
+    };
     var Progress = function (c, f) {    // обновление прогрессбара
         if (!f) f = 1;
         ge('vk_links_container').innerHTML = vkProgressBar(c, f, 600);
     };
-    // 3. Когда все библиотеки подключены, 
-    var JsZipOnload = function () {
+    // Когда все библиотеки подключены
+    JsZipConnect(function () {
         zip = new JSZip();                          // Создание объекта JSZip в ранее объявленную переменную
         vkApis.photos_hd(oid, aid, function (r) {   // Получение списка ссылок
             links = r;
             links_length = links.length;
             dlphoto(links_length - 1);              // Запуск рекурсии с последней ссылки
         }, Progress);
-    }
-    // 2. Подключение библиотеки JSZip
-    var FileSaverOnload = function () {
-        try {
-            var blobSupported = !!URL.createObjectURL;  // Проверка поддержки Blob для подключения Blob.js в старых браузерах (Opera < 15 и Firefox < 20)
-        } catch (e) {}
-        if (!blobSupported)
-            AjCrossAttachJS('http://vkopt.net/blob', 'BlobJs', FileSaverOnload);
-        else
-            if (typeof JSZip != "undefined")
-                JsZipOnload();
-            else
-                AjCrossAttachJS('http://vkopt.net/jszip', 'JsZip', JsZipOnload);
-    }
-    // 1. Подключение библиотеки FileSaver.js
-    if (typeof saveAs != "undefined")
-        FileSaverOnload();
-    else
-        AjCrossAttachJS('http://vkopt.net/FileSaver', 'FileSaver', FileSaverOnload);
+    });
 }
 
 function vkGetPageWithPhotos(oid,aid){  


### PR DESCRIPTION
В окне со списком вики-страниц появляется ссылка для скачивания ZIP-архивом всех страниц в виде html:
![- 11 06 2015 - 11 57 12](https://cloud.githubusercontent.com/assets/2682026/8103535/e5065410-1031-11e5-9079-abaa0c1e21b0.png)
Страницы скачиваются вместе с картинками, которые конвертируются в inline data:uri
Функция может пригодиться, когда в группе выкладывают полезные инструкции в виде вики-страниц. Берешь, скачиваешь, скидываешь на телефон например и всё, независимый от интернета комплект мануалов всегда с тобой.

Также немного изменена функция отображения самого списка: к ссылкам добавлен класс `vk_wiki_link` и дополнительный атрибут `pid`, потому что было бы глупо снова запрашивать список страниц, когда вот они все уже лежат, да и парсить id страниц из href как-то не комильфо.

И еще я извлек функции подгрузки внешних библиотек, чтобы их удобнее было использовать в других функциях. гибкость, короче.