### PR TITLE
Обход away для русских ссылок

### DIFF
--- a/source/vk_main.js
+++ b/source/vk_main.js
@@ -327,8 +327,14 @@ function vkProccessLinks(el){
 
 function ProcessAwayLink(node){
   var href=node.getAttribute('href');
-  if (href && href.indexOf('away.php?')!=-1){ 
-	var lnk=decodeURIComponent((href.match(/to=([^&]+)/) || [])[1]);
+  if (href && href.indexOf('away.php?')!=-1){
+   var to = (href.match(/to=([^&]+)/) || [])[1];
+   try {
+       var lnk = decodeURIComponent(vkLinksUnescapeCyr(to));
+   }
+   catch (e) {
+       var lnk = decodeURIComponent(to);
+   }
    if (!lnk) return;
 	node.setAttribute('href',lnk);
   }


### PR DESCRIPTION
возвращена `vkLinksUnescapeCyr` и обёрнуто в try, потому что при исходящем сообщении ссылка кодируется в UTF-8, а при входящем - в CP1251