### PR TITLE
#110 - Исправление синхронизации потоков для джетпака

### DIFF
--- a/background.js
+++ b/background.js
@@ -597,8 +597,16 @@ ext_api={
          }
       */
       if (browser.mozilla && !Components.classes) {    // Firefox Jetpack
+          options.mozTime=Date.now();
           self.port.emit("ajax", options);
-          self.port.on("ajax_response", callback);
+          function ajaxResponse(obj) {
+              if (options.mozTime == obj.mozTime) {
+                  delete obj.mozTime;
+                  callback(obj);
+                  self.port.removeListener("ajax_response", ajaxResponse);
+              }
+          }
+          self.port.on("ajax_response", ajaxResponse);
       }
       else {
           if (!options.url || (options.url || '').replace(/^\s+|\s+$/g, '') == '') {

--- a/builds/firefoxJetpack/resources/vkopt/lib/main.js
+++ b/builds/firefoxJetpack/resources/vkopt/lib/main.js
@@ -49,6 +49,7 @@ function downloadFile(url, name) {
 
 function Ajax(options, worker) {
     function callback(obj) {
+        obj.mozTime=options.mozTime;
         worker.port.emit("ajax_response", obj);
     }
 


### PR DESCRIPTION
Исправление для джетпака, чтобы на HTTP соединении не появлялась ошибка "epic fail".
Каждому сообщению будет добавляться идентификатор - время отправки запроса. Думаю, время в миллисекундах можно использовать в качестве идентификатора.

За наводку спасибо @Evengard