### PR TITLE
Функция, отключающая преобразование ссылок в диалогах в миниатюры

### DIFF
--- a/source/vk_main.js
+++ b/source/vk_main.js
@@ -1291,6 +1291,10 @@ vk_im={
       vk_im.add_prevent_hide_cbox();
       //vkMsgStatsBtn();
       vk_im.add_menus();
+      if (getSet(76) == 'y')    // Отключение функции преобразования ссылок в ЛС в миниатюры с текстом
+          Inj.Wait('cur.imMedia', function () {
+              Inj.Start('cur.imMedia.checkURL', 'return;');
+          });
    },
    add_menus:function(){
       if (!ge('vk_im_menu')){

--- a/source/vk_settings.js
+++ b/source/vk_settings.js
@@ -636,7 +636,8 @@ function vkInitSettings(){
      {id:62,  text: "seWriteBoxWithoutFastChat"},
      {id:68,  text: "seTypingNotify"},
      {id:81,  text: "seDialogsReplyBtn"},
-     {id:89,  text: "seDisableIMFavicon"}
+     {id:89,  text: "seDisableIMFavicon"},
+     {id:76,  text: "seDisableLinkConvert"}
     ],
     vkInterface:[
       {id:21,  wiki:"seADRem", text:IDL("seADRem")+vkCheckboxSetting(44,IDL("seAdNotHideSugFr"),true)},
@@ -704,7 +705,7 @@ function vkInitSettings(){
   };
 
    //LAST 104
-   //FREE 20,76,102
+   //FREE 20,102
 
    vkSetsType={
       "on"  :[IDL('on'),'y'],

--- a/source/vklang.js
+++ b/source/vklang.js
@@ -727,6 +727,7 @@ vk_lang_ru={
    ,"seUseHtml5ForAudio":"\u0418\u0441\u043f\u043e\u043b\u044c\u0437\u043e\u0432\u0430\u0442\u044c HTML5 \u0430\u0443\u0434\u0438\u043e \u043f\u043b\u0435\u0435\u0440"
    ,"seUseHTML5ForSave":"\u0418\u0441\u043F\u043E\u043B\u044C\u0437\u043E\u0432\u0430\u0442\u044C HTML5 \u0434\u043B\u044F \u0441\u043E\u0445\u0440\u0430\u043D\u0435\u043D\u0438\u044F \u0444\u0430\u0439\u043B\u043E\u0432"
    ,"seTurningPosts":"\u041a\u043d\u043e\u043f\u043a\u0438 \u043b\u0438\u0441\u0442\u0430\u043d\u0438\u044f \u043f\u043e\u0441\u0442\u043e\u0432"
+   ,"seDisableLinkConvert":"\u041d\u0435 \u043f\u0440\u0435\u043e\u0431\u0440\u0430\u0437\u043e\u0432\u044b\u0432\u0430\u0442\u044c \u0441\u0441\u044b\u043b\u043a\u0438 \u0432 \u0434\u0438\u0430\u043b\u043e\u0433\u0430\u0445"
 };
 
 vk_lang_en={//by Hzy
@@ -1610,6 +1611,7 @@ vk_lang_en={//by Hzy
   ,"seUseHtml5ForAudio":"Use HTML5 as audio player"
   ,"seUseHTML5ForSave":"Use HTML5 for file saving"
   ,"seTurningPosts":"Turning posts buttons"
+  ,"seDisableLinkConvert":"Don't convert links in dialogs"
 };
  
 vk_lang_ua={//by Vall (id3476823) and Vall_gorr (id119992149)

--- a/source/vkopt.js
+++ b/source/vkopt.js
@@ -17,7 +17,7 @@ if (!window.vk_DEBUG) var vk_DEBUG=false;
 /* EXT CONFIG */
 if (!window.DefSetBits)
 
-var DefSetBits='yyyynnyyynyyy0n0yy0nnnynyyynyy0nynynnnnyy0yyy1yynnnnny0nynynynnnnyynnynnnynyyyynnyn3nnnnynynnnnnyynnnnnnn-3-0-#c5d9e7-#34a235-1-';
+var DefSetBits='yyyynnyyynyyy0n0yy0nnnynyyynyy0nynynnnnyy0yyy1yynnnnny0nynynynnnnyynnynnnynynyynnyn3nnnnynynnnnnyynnnnnnn-3-0-#c5d9e7-#34a235-1-';
 
 var DefExUserMenuCfg='11111110111111111111'; // default user-menu items config
 var vk_upd_menu_timeout=20000;      //(ms) Update left menu timeout


### PR DESCRIPTION
Когда в "диалогах" пишешь сообщение, и вставляешь ссылку, при отправке она превратится в картинку во весь экран диалога, с заголовком и текстом. Причем крестика для удаления этой миниатюры нет, как на стенах. Мне это не нравится, поэтому предлагаю функцию отключения этой "мега-фичи".
Стены не затрагивает, только диалоги. 
Настройка находится на вкладке "Сообщения".