### PR TITLE
Исправление пропадания настроек при выходе

### DIFF
--- a/source/vk_main.js
+++ b/source/vk_main.js
@@ -292,7 +292,7 @@ function VkOptMainInit(){
   setTimeout(vkFriendsCheckRun,2000);
   window.vk_vid_down &&  setTimeout(vk_vid_down.vkVidLinks,0);
   if (vkgetCookie('IDFriendsUpd') && (vkgetCookie('IDFriendsUpd') != '_')) {	vkShowFriendsUpd();  }
-  
+  addEvent(ge('logout_link'), 'click', function () { ls.remove('last_reloaded') });
 }
 
 function vkOnDocumentClick() {


### PR DESCRIPTION
В common.js появились следующие строки

``` JS
  if (!vk.id && ls.checkVersion() && ls.get('last_reloaded')) {
    try {
      window.localStorage.clear();
    } catch (e) {}
  }
```

Я не знаю, что значит хранимая переменная `last_reloaded`, поэтому удалять её предлагаю только при нажатии на "выйти". И тогда хранилище чиститься не будет.
