### PR TITLE
Стрелочка юзерменю не на новой строке

### DIFF
--- a/source/vk_users.js
+++ b/source/vk_users.js
@@ -269,6 +269,7 @@ function vkProcessUserLink(link){
 	inel.setAttribute("onmousedown","event.cancelBubble = true;");
 	inel.innerHTML=USERMENU_SYMBOL;
 	link.setAttribute('exuser',true);
+	try{ if (!geByTag('small',link)[0].innerText) link.removeChild(geByTag('br',link)[0]); }catch(e){}    // Чтобы в группах в блоке "участники" стрелочка была не на новой строке
 	if (getSet(22)=='y' && link.parentNode.parentNode && link.parentNode.parentNode.id=='profile_groups'){
 		inel.setAttribute('class','vk_usermenu_btn fl_r');
 		link.parentNode.insertBefore(inel,link);


### PR DESCRIPTION
В группах в блоке "Участники" сейчас стрелочки для юзерменю переносятся на новую строку. Красивее будет, если они будут на той же строке. До и после:
![- 08 07 2015 - 11 22 39](https://cloud.githubusercontent.com/assets/2682026/8566104/525f20d6-2564-11e5-9b43-11a942b1fb52.png)
Правда, не знаю, что будет если имя будет слишком длинное. Но я готов пожертвовать плохим видом длинных имен ради хорошего вида всех остальных имен.