### PR TITLE
Фича "При щелчке на Фотография 1 из 40" вынесена в настройки

### DIFF
--- a/source/vk_media.js
+++ b/source/vk_media.js
@@ -21,13 +21,14 @@ vk_phviewer={
 
       vkPVNoCheckHeight=function(){return !window.PVShowFullHeight};
 
-      Inj.Before('photoview.onResize','cur.pvCurrent.height * c >','vkPVNoCheckHeight() && ');
-      Inj.Before('photoview.doShow','h * c > ','vkPVNoCheckHeight() && ');
-
+      if (PHOTO_FEATURE) {
+         Inj.Before('photoview.onResize', 'cur.pvCurrent.height * c >', 'vkPVNoCheckHeight() && ');
+         Inj.Before('photoview.doShow', 'h * c > ', 'vkPVNoCheckHeight() && ');
+         Inj.End('photoview.afterShow', 'vkPVAfterShow();');
+      }
       // предотвращаем при использовании временного вьювера изменение URL страницы
-      Inj.Start('Photoview.updateLoc',"if (/^vkph_/.test((cur.pvCurPhoto && cur.pvCurPhoto.id) || '')) return;");
+      Inj.Start('Photoview.updateLoc',"if (/^vkph_/.test((cur.pvCurPhoto && cur.pvCurPhoto.id) || '')) return; if (ge('pv_album_name')) vkPVPhotoMover();");
       
-      Inj.End('photoview.afterShow','vkPVAfterShow();');
       if (browser.opera && intval(browser.version)==12) Inj.Start('photoview.canFullscreen','return true;');
       if (getSet(71)=='y') 
       Inj.Before('Photoview.commentTo','if (!v', 'vk_phviewer.reply_to(comm, toId, event, rf,v,replyName); if(false)' );
@@ -125,9 +126,6 @@ function vkPVAfterShow(){
       Photoview.doShow();
 	};
 	if (ge('pv_summary')) ge('pv_summary').setAttribute('onclick','vkPVChangeView()');
-   if (ge('pv_album_name')){
-      vkPVPhotoMover();
-   }
 }
 /*
 var orig_cur_chooseMedia=cur.chooseMedia;

--- a/source/vkopt.js
+++ b/source/vkopt.js
@@ -66,6 +66,7 @@ var VIDEO_PLAYER_DBG_ON = false; // включить отладочную инф
 var LOAD_HEADERS_BY_HEAD_REQ = false; // для получения запросом только хидеров использовать HEAD запрос (иначе GET c хидером запроса Range: bytes=0-1)
 var DISABLE_CHATS_TYPING_NOTIFY = false; // при включенной опции уведомления о набирающих сообщение, отключает уведомления от печатающих в чатах
 var BLOCK_LOCALSTORAGE_CLEAR = true; // пытаемся перезаписать родную функцию очистки хранилища
+var PHOTO_FEATURE = true; // фича, при которой по щелчку на "Фотография 1 из 40" переключается режим "подгонять/не подгонять фото в просмотрщике по высоте под высоту видимой области".
 
 var VKOPT_CFG_LIST=[
          'vk_DEBUG',
@@ -97,7 +98,8 @@ var VKOPT_CFG_LIST=[
          'ENABLE_CACHE',
          'VIDEO_PLAYER_DBG_ON',
          'LOAD_HEADERS_BY_HEAD_REQ',
-         'DISABLE_CHATS_TYPING_NOTIFY'
+         'DISABLE_CHATS_TYPING_NOTIFY',
+         'PHOTO_FEATURE'
 ];
 
 var vkNewSettings=[98,99,100,79,101,103,104,19]; //"new" label on settings item


### PR DESCRIPTION
Предлагаю создать настройку для фичи, при которой по щелчку на "Фотография 1 из 40" переключается режим "подгонять/не подгонять фото в просмотрщике по высоте под высоту видимой области". Я об этой фиче не знал, да она мне и не нужна, однако для неё делается 3 модификации функций ВК.
Текст придумать сложно, но пока такой: 
`При щелчке на "Фотография 1 из 40" не подгонять фото под высоту экрана`