### PR TITLE
Настройка для функции добавления фильтра на странице "Группы"

### DIFF
--- a/source/vk_page.js
+++ b/source/vk_page.js
@@ -1977,14 +1977,14 @@ vk_pages={
 };
 
 function vkGroupsList(){
-   Inj.Before('GroupsList.showMore','var name','if (vkGroupsListCheckRow(row)) continue;');
+   if (getSet(102)=='y') Inj.Before('GroupsList.showMore','var name','if (vkGroupsListCheckRow(row)) continue;');
    
    if (getSet(74)=='y')  
       Inj.Replace('GroupsList.showMore',/html\.join\(['"]+\)/g, "vkModAsNode(html.join(''),vkGroupDecliner)"); 
 }
 
 function vkGroupsListPage(){
-	vkGrLstFilter();
+   if (getSet(102)=='y') vkGrLstFilter();
    if (getSet(74)=='y')
       vkGroupDecliner();
     vk_groups.leave_all_btn();

--- a/source/vk_settings.js
+++ b/source/vk_settings.js
@@ -686,6 +686,7 @@ function vkInitSettings(){
       {id:100,  text: "seTopicSearch"}
       //{id:64,  text: "seToTopOld"}
      ,{id:19,  text: "seTurningPosts"}
+     ,{id:102, text: "seGroupsFilter"}
     ],
 	Sounds:[
 	  {id:48,   text: "ReplaceVkSounds"}	
@@ -718,7 +719,6 @@ function vkInitSettings(){
   };
 
    //LAST 104
-   //FREE 76,102
 
    vkSetsType={
       "on"  :[IDL('on'),'y'],

--- a/source/vklang.js
+++ b/source/vklang.js
@@ -738,6 +738,7 @@ vk_lang_ru={
    ,"Site":"\u0421\u0430\u0439\u0442"
    ,"StartDate":"\u0414\u0430\u0442\u0430 \u043d\u0430\u0447\u0430\u043b\u0430"
    ,"AbilityToPost":"\u0412\u043e\u0437\u043c\u043e\u0436\u043d\u043e\u0441\u0442\u044c \u043f\u0438\u0441\u0430\u0442\u044c"
+   ,"seGroupsFilter":"\u0424\u0438\u043b\u044c\u0442\u0440 \u043d\u0430 \u0441\u0442\u0440\u0430\u043d\u0438\u0446\u0435 \"\u0413\u0440\u0443\u043f\u043f\u044b\""
 };
 
 vk_lang_en={//by Hzy
@@ -1633,6 +1634,7 @@ vk_lang_en={//by Hzy
   ,"Site":"Site"
   ,"StartDate":"Start date"
   ,"AbilityToPost":"Ability to post"
+  ,"seGroupsFilter":"Filter at \"Communities\" page"
 };
  
 vk_lang_ua={//by Vall (id3476823) and Vall_gorr (id119992149)


### PR DESCRIPTION
Теперь возможно отключить функцию добавления фильтра по типам на странице "Мои группы".
Номер настройки взял 23, он не числился свободным, но его использования я не нашел.