### PR TITLE
Уменьшение вызовов Inj при отключенных настройках

### DIFF
--- a/source/vk_main.js
+++ b/source/vk_main.js
@@ -286,7 +286,6 @@ function VkOptMainInit(){
   if (getSet(16) == 'y') UserOnlineStatus();
   vkFavOnlineChecker();
   vkFaveOnlineChecker();
-  vk_audio_player.init();
   vkMoneyBoxAddHide();
   if (ENABLE_HOTFIX) vkCheckUpdates();
   setTimeout(vkFriendsCheckRun,2000);
@@ -1560,8 +1559,8 @@ function vkIM(){
       Inj.Replace('IM.wrapFriends',/text\.push\(/g,'vkIMwrapFrMod(text,');
       Inj.Replace('IM.wrapFriends','text.join(','vkIMwrapFrModSort(text,');   
    }
-   
-   Inj.Start('IM.checked','vkImEvents(response);');
+
+   if (getSet(68)=='y') Inj.Start('IM.checked','vkImEvents(response);');
    
    Inj.Before('IM.applyPeer','cur.actionsMenu.setItems','vkIMModActMenu(types,peer,user);');
    if (window.cur && cur.tabs) IM.applyPeer();
@@ -1617,9 +1616,7 @@ function vkImTypingEvent(uid,need_close){
       uid=uid.uid;
    
    if (chat && DISABLE_CHATS_TYPING_NOTIFY) return;
-   
-   if (getSet(68)=='n') return;
-   
+
    var NOTIFY_TIMEOUT= 15000; // 15sec
    
    if (need_close){
@@ -1767,7 +1764,7 @@ function vkNotifier(){
 	  */
      
     if (getSet(62)=='y')  FastChat.selectPeer=function(mid,e){return showWriteMessageBox(e, mid)};
-    Inj.Start('FastChat.imChecked','vkFcEvents(response);');    
+    if (getSet(68)=='y') Inj.Start('FastChat.imChecked','vkFcEvents(response);');
 }
 
 function vkFcEvents(response){

--- a/source/vk_media.js
+++ b/source/vk_media.js
@@ -176,7 +176,7 @@ var vk_photos = {
 	  .vkPVPhotoMoverOpen #pv_author_img{display:none;}\
    ',
    inj_photos:function(){
-      Inj.Before('photos.loaded','while','vk_photos.album_process_node(d);');
+      if (getSet(93)=='y') Inj.Before('photos.loaded','while','vk_photos.album_process_node(d);');
    },
    page:function(){
       vk_photos.album_process_node();
@@ -2395,10 +2395,10 @@ vk_videos = {
       return code;
    },
    inj_common:function(){
-      Inj.Before('showVideo','ajax.post','vk_videos.change_show_video_params(options);');
+      if (VIDEO_AUTOPLAY_DISABLE) Inj.Before('showVideo','ajax.post','vk_videos.change_show_video_params(options);');
    },
    inj_html5:function(){
-      Inj.End('html5video.initHTML5Video','vkOnRenderFlashVars(vars);');
+      if (getSet(2)=='y') Inj.End('html5video.initHTML5Video','vkOnRenderFlashVars(vars);'); // перехват flash-переменных для скачивания видео
    },
    inj_videoview:function(){
       window.vk_vid_down && vk_vid_down.inj_vidview();
@@ -3135,14 +3135,10 @@ vk_audio_player={
    #gp.reverse .vka_ctrl.vol .vol_panel{margin-top: -54px;}\
    .gp_vka_ctrls{position:absolute; width:137px; margin-top:34px; margin-left: 5px; padding:3px; border-radius:0 0 4px 4px; background:rgba(218, 225, 232, 0.702); }\
    ',
-   scroll_to_track_enabled:true,
    inj:function(){
       if (getSet(75)=='y') vk_audio_player.gpCtrlsInit();
-      Inj.Start('audioPlayer.scrollToTrack','if (!vk_audio_player.scroll_to_track_enabled) return;');
+      if (getSet(85)=='y') Inj.Start('audioPlayer.scrollToTrack','return;');
       if (getSet(104)=='y') Inj.Before('audioPlayer.initPlayer','browser.flash','false && ');
-   },  
-   init:function(){
-      if (getSet(85)=='y') vk_audio_player.scroll_to_track_enabled=false;
    },
    gpCtrlsInit:function(){
       Inj.End('audioPlayer.setGraphics','vk_audio_player.gpCtrls();');
@@ -3224,7 +3220,7 @@ vk_audio={
    ',
    album_cache:{},
    inj_common:function(){
-      Inj.Start('playAudioNew','if (vk_audio.prevent_play_check()) return;');
+      if (getSet(0)=='y') Inj.Start('playAudioNew','if (vk_audio.prevent_play_check()) return;'); // для предотвращения воспроизведения при нажатии на "скачать"
    },
    remove_trash:function(s){
       s=vkRemoveTrash(s);

--- a/source/vk_page.js
+++ b/source/vk_page.js
@@ -1962,16 +1962,15 @@ vk_pages={
       Inj.Before('Wall.replyTo','toggleClass','vk_wall.cancel_reply_btn(post);');
    },
    inj_common:function(){
-      Inj.Start('showWiki','if (vk_pages.is_wiki_box_disabled(arguments)) return;');
+      if (getSet(86)=='y') Inj.Start('showWiki','if (vk_pages.is_wiki_box_disabled(arguments)) return;');
    },
    is_wiki_box_disabled:function(args){
-      var box_disable=(getSet(86)=='y');
       var page=args[0], 
           ev = args[2];
       //console.log(ev);
       if (!ev) return false;
       var el= ev.target || ev.srcElement || {};
-      return box_disable && page && page.w && /^wall-?\d+_\d+$/.test(page.w+"") && (el.tagName=='SPAN' || el.tagName=='A');
+      return page && page.w && /^wall-?\d+_\d+$/.test(page.w+"") && (el.tagName=='SPAN' || el.tagName=='A');
    }
    
 


### PR DESCRIPTION
В коде часто встречается ситуация, когда модифицируется функция ВК, а проверка соответствующей настройки идет уже потом, при срабатывании модифицированной функции. Я считаю, что лучше при выключенной настройке вообще не модифицировать функции ВК, к тому же методы класса Inj самые медленные, поэтому отключение функций ускорит работу.