### PR TITLE
Не сериализовывать массивы при отправке

### DIFF
--- a/background.js
+++ b/background.js
@@ -643,7 +643,7 @@ ext_api={
               headers['Content-type'] = contentType;
 
           if (data && (typeof data == 'object') && isEmptyObject(data)) data = null;
-          if (data && (typeof data == 'object')) data = serialize(data);
+          if (data && (typeof data == 'object') && !(data instanceof Array)) data = serialize(data);
 
           if (~contentType.indexOf('multipart/form-data') && method == 'POST' && data && data.length) {
               var buffer = new Uint8Array(data.length);


### PR DESCRIPTION
Позволяет кроссдоменно отправлять файлы в виде массива байтов.