### PR TITLE
Не показывать всплывающий профиль после клика

### DIFF
--- a/source/vk_users.js
+++ b/source/vk_users.js
@@ -629,24 +629,25 @@ function vkShowProfile(el,html,uid,right){
             ge('vkprofonlineinfo' + uid).innerHTML = html;
         });
     }
-   
-	if (allowShowPhoto) fadeIn('vkbigPhoto');//show('vkbigPhoto');
-      var xy=getXY(el); 
-      var height=getScrollTop()+getScrH();    
-      var top= (xy[1]+pb.offsetHeight>height)?height-pb.offsetHeight-10:xy[1];
-      top=(top<getScrollTop())?getScrollTop():top;
-      
-      var left=xy[0] - pb.offsetWidth + 5;
-      if (left < 0) right = true;
-      //alert(getScrollTop()+"\n"+getScrH()+"\n"+height+"\n"+(xy[1]+el.offsetHeight)+"\n"+el.offsetHeight);
-      if (right) {
-        p.style.left = (xy[0] + el.offsetWidth + 10) + "px";
-        p.style.top = top+"px";
-        
-      }else {
-        p.style.left = left+"px";//(xy[0] - p.offsetWidth - 10)+"px";
-        p.style.top = top+"px";
-      }
+
+    var xy = getXY(el);
+    if (allowShowPhoto && xy[0] != 0 && xy[1] != 0) {
+        fadeIn('vkbigPhoto');//show('vkbigPhoto');
+        var height = getScrollTop() + getScrH();
+        var top = (xy[1] + pb.offsetHeight > height) ? height - pb.offsetHeight - 10 : xy[1];
+        top = (top < getScrollTop()) ? getScrollTop() : top;
+
+        var left = xy[0] - pb.offsetWidth + 5;
+        if (left < 0) right = true;
+        //alert(getScrollTop()+"\n"+getScrH()+"\n"+height+"\n"+(xy[1]+el.offsetHeight)+"\n"+el.offsetHeight);
+        if (right) {
+            p.style.left = (xy[0] + el.offsetWidth + 10) + "px";
+            p.style.top = top + "px";
+        } else {
+            p.style.left = left + "px";//(xy[0] - p.offsetWidth - 10)+"px";
+            p.style.top = top + "px";
+        }
+    }
 }
 
 function vkHidePhoto() {


### PR DESCRIPTION
У меня случается такая шняга: я хочу нажать на какую-нибудь ссылку-аватарку (человек или группа), чтобы перейти на страницу. И после перехода в левом верхнем углу появляется всплывающий профиль. И приходится специально навести-увести курсор с него, чтобы он пропал.
Происходит следующее: я навожу курсор на аватарку, начинает грузиться профиль через API, я щелкаю на аватарку, страница открывается, а после этого профиль только загрузился, и всплывает в позиции 0, 0. Причем сам элемент-ссылка всё еще существует и даже isVisible возвращает true. 
Скриншот:
![- 30 07 2015 - 11 10 00](https://cloud.githubusercontent.com/assets/2682026/8978533/a71cf690-36ab-11e5-845d-b80e5d1ec27b.png)
