### PR TITLE
Коррекция для подписывания в AMO

### DIFF
--- a/background.js
+++ b/background.js
@@ -251,7 +251,7 @@ var ex_loader = {
    get_scripts:function(url,callback,in_frame){
       var api_allowed = false;
       var domain=url;
-      if (url=='about:blank'){ 
+      if (url=='about:'+'blank'){    // AMO folly
          callback([]);
          return;
       }

--- a/builds/_firefox_jetpack_pack.bat
+++ b/builds/_firefox_jetpack_pack.bat
@@ -1,3 +1,3 @@
 del vkopt_firefox_jetpack.xpi
-_zip_packer.py firefoxJetpack vkopt_firefox_jetpack.xpi
+_zip_packer.py firefoxJetpack vkopt_firefox_jetpack.xpi "" ^\\.
 pause

--- a/builds/_firefox_jetpack_pack.sh
+++ b/builds/_firefox_jetpack_pack.sh
@@ -1,2 +1,2 @@
 rm vkopt_firefox_jetpack.xpi
-./_zip_packer.py firefoxJetpack vkopt_firefox_jetpack.xpi
+./_zip_packer.py firefoxJetpack vkopt_firefox_jetpack.xpi "" ^\\.

--- a/builds/firefox/install.rdf
+++ b/builds/firefox/install.rdf
@@ -19,15 +19,15 @@
         <!-- fennec -->
         <em:id>{a23983c0-fd0e-11dc-95ff-0800200c9a66}</em:id>
         <em:minVersion>4.0</em:minVersion>
-        <em:maxVersion>80.*</em:maxVersion>
+        <em:maxVersion>40.0</em:maxVersion>
       </Description>
     </em:targetApplication>
     <em:targetApplication>
       <Description>
         <!-- fennec2 -->
         <em:id>{aa3c5121-dab2-40e2-81ca-7ea25febc110}</em:id>
-        <em:minVersion>4.0</em:minVersion>
-        <em:maxVersion>80.*</em:maxVersion>
+        <em:minVersion>10.0a1</em:minVersion>
+        <em:maxVersion>44.0</em:maxVersion>
       </Description>
     </em:targetApplication>
     <em:targetApplication>
@@ -35,7 +35,7 @@
         <!-- firefox -->
         <em:id>{ec8030f7-c20a-464f-9b0e-13a3a9e97384}</em:id>
         <em:minVersion>4.0</em:minVersion>
-        <em:maxVersion>80.*</em:maxVersion>
+        <em:maxVersion>44.0</em:maxVersion>
       </Description>
     </em:targetApplication>
     <em:targetApplication>
@@ -43,7 +43,7 @@
         <!-- seamonkey -->
         <em:id>{92650c4d-4b8e-4d2a-b7eb-24ecf4f6b63a}</em:id>
         <em:minVersion>2.5</em:minVersion>
-        <em:maxVersion>80.*</em:maxVersion>
+        <em:maxVersion>2.39</em:maxVersion>
       </Description>
     </em:targetApplication>
   </Description>

--- a/builds/firefoxJetpack/harness-options.json
+++ b/builds/firefoxJetpack/harness-options.json
@@ -10,7 +10,7 @@
  "manifest": {
   "vkopt/main": {
    "docsSHA256": null, 
-   "jsSHA256": "3370468543c731ecf0305129a54f3a399ddab7c252e5279eed7ab9361835139b", 
+   "jsSHA256": "ef8682a23d2163c20d058f7214554deb9bfdc0213048a1c2c14fc8cdbfdb7c53",
    "moduleName": "main", 
    "packageName": "vkopt", 
    "requirements": {

--- a/builds/firefoxJetpack/install.rdf
+++ b/builds/firefoxJetpack/install.rdf
@@ -3,7 +3,7 @@
    - file, You can obtain one at http://mozilla.org/MPL/2.0/. --><RDF xmlns="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:em="http://www.mozilla.org/2004/em-rdf#">
   <Description about="urn:mozilla:install-manifest">
     <em:id>vkopt@vkopt.net</em:id>
-    <em:version>2.3.0</em:version>
+    <em:version>2.3.2</em:version>
     <em:type>2</em:type>
     <em:bootstrap>true</em:bootstrap>
     <em:unpack>true</em:unpack>
@@ -12,15 +12,15 @@
     <em:targetApplication>
       <Description>
         <em:id>{ec8030f7-c20a-464f-9b0e-13a3a9e97384}</em:id>
-        <em:minVersion>26.0</em:minVersion>
-        <em:maxVersion>99.0</em:maxVersion>
+        <em:minVersion>3.5</em:minVersion>
+        <em:maxVersion>44.0</em:maxVersion>
       </Description>
     </em:targetApplication>
 
     <!-- Front End MetaData -->
-    <em:name>VkOpt</em:name>
+    <em:name>VkOpt Jetpack</em:name>
     <em:description>Добавление множества функций для сайта ВКонтакте</em:description>
-    <em:creator>KiberПсих</em:creator>
+    <em:creator>VkOpt team</em:creator>
     
     
     

--- a/content_script.js
+++ b/content_script.js
@@ -183,12 +183,15 @@ var ex_ldr={
       return true;      
    },
    inj_script:function(script,info,by_src){
+      var cre = function(t){    // AMO folly
+          return doc.createElement(t);
+      };
       var ext=(info || ".js").split('.').pop();
       switch(ext){
          case 'js':
             if (ext_browser.opera) win.eval(script);
             else {   /*if (ext_browser.chrome || ext_browser.safari || ext_browser.maxthon)*/
-               var js = doc.createElement('script');
+               var js = cre('script');
                js.type = 'text/javascript';
                js.charset = 'UTF-8';
                if (!by_src)

--- a/source/vk_face.js
+++ b/source/vk_face.js
@@ -789,12 +789,8 @@ vk_menu={
    get_custom_links:function(){
       try {
          return (JSON.parse(vkGetVal('menu_custom_links') || '[]') || []);
-      } catch(e) { 
-         try {
-            return (eval(vkGetVal('menu_custom_links') || '[]') || []);
-         } catch(e) { 
+      } catch(e) {
             return [];
-         }
       }
    },
    custom_settings:function(){
@@ -1439,7 +1435,7 @@ function vkGetCalendarInfo(callback,cnt){ //callback(month, year, events, holida
       }
       res=res.split(');')[0];
 		//eval(callback+'('+res+')');
-      var args=eval('['+res+']');
+      var args=JSON.parse('['+res+']');
       callback.apply(this,args);
 	});
 }

--- a/source/vk_face.js
+++ b/source/vk_face.js
@@ -1131,7 +1131,7 @@ function vkMenu(){//vkExLeftMenu
     if (vkMenuCurrentSub!=cur) {  vkMenuHide();  show(cur);   vkMenuCurrentSub=cur; }
     clearTimeout(vkMenuHider);
   };
-  vkMenuItemOut=function(){ clearTimeout(vkMenuHider);  vkMenuHider=setTimeout(vkMenuHide,vkMenuHideTimeout); };
+  vkMenuItemOut=function(){ clearTimeout(vkMenuHider);  vkMenuHider=setTimeout(function(){vkMenuHide();},vkMenuHideTimeout); };
   vkMenuHide=function(){if (vkMenuCurrentSub){ hide(vkMenuCurrentSub); vkMenuCurrentSub=null; }};
   var setActions=function(elem){
       if (elem){
@@ -1374,7 +1374,7 @@ function UserOnlineStatus(status) {// ADD LAST STATUS
 			}
 		//}
 		/* vkGenDelay() -random для рассинхронизации запросов разных вкладок, иначе запросы со всех вкладок будут одновременно слаться. */
-		vk_check_online_timeout=setTimeout(UserOnlineStatus,vkGenDelay(vk_upd_menu_timeout,status!=null));
+		vk_check_online_timeout=setTimeout(function(){UserOnlineStatus();},vkGenDelay(vk_upd_menu_timeout,status!=null));
 	};
 	if (status!=null){
 		show_status(status);
@@ -1396,7 +1396,7 @@ function UserOnlineStatus(status) {// ADD LAST STATUS
 				vkCmd('user_online_status',st);// /*res.response[0].online*/ шлём полученный статус в остальные вкладки
 				//vklog('Online status >> [onStorage] ');
 			} else {
-				vk_check_online_timeout=setTimeout(UserOnlineStatus,vkGenDelay(vk_upd_menu_timeout));
+				vk_check_online_timeout=setTimeout(function(){UserOnlineStatus();},vkGenDelay(vk_upd_menu_timeout));
 			}
 		});  
 	}

--- a/source/vk_face.js
+++ b/source/vk_face.js
@@ -705,7 +705,7 @@ function vkMakeRightBar(){
 		if (b) bar.appendChild(b);
 	}
    updSideTopLink(true);
-   setTimeout("updSideTopLink(true);",500);
+   setTimeout(function(){updSideTopLink(true);},500);
 }
 //if (getSet(44)=='y') vkMoveSuggFrBox();
 

--- a/source/vk_face.js
+++ b/source/vk_face.js
@@ -851,15 +851,15 @@ vk_menu={
       var edt=cfg[idx];
       if (sub_idx!=null) edt=edt[2][sub_idx];
       var p=ge('vk_m_item'+id);
-      p.innerHTML='<div class="button_gray fl_r" onclick="vk_menu.save(1,'+params+')"><button>OK</button></div>\
+      val(p,'<div class="button_gray fl_r" onclick="vk_menu.save(1,'+params+')"><button>OK</button></div>\
       <input type="text" placeholder="http://" id="vk_menu_edt_link'+id+'" onkeyup="vk_menu.save(event,'+params+')" value="'+edt[0]+'">\
-      <input type="text" placeholder="Title" id="vk_menu_edt_title'+id+'"  onkeyup="vk_menu.save(event,'+params+')" value="'+edt[1]+'">';
+      <input type="text" placeholder="Title" id="vk_menu_edt_title'+id+'"  onkeyup="vk_menu.save(event,'+params+')" value="'+edt[1]+'">');
       return false;
    },
    add:function(to_idx){
       var id=(to_idx!=null?to_idx:'');
       var p=ge('vkm_add_frm'+id);
-      p.innerHTML='<div class="button_gray fl_r" onclick="vk_menu.add_checkkey(1,'+to_idx+')"><button>OK</button></div><input type="text" placeholder="http://" id="vk_menu_add_link'+id+'" onkeyup="vk_menu.add_checkkey(event,'+to_idx+')" value=""><input type="text" placeholder="Title" id="vk_menu_add_title'+id+'"  onkeyup="vk_menu.add_checkkey(event,'+to_idx+')" value="">';
+      val(p,'<div class="button_gray fl_r" onclick="vk_menu.add_checkkey(1,'+to_idx+')"><button>OK</button></div><input type="text" placeholder="http://" id="vk_menu_add_link'+id+'" onkeyup="vk_menu.add_checkkey(event,'+to_idx+')" value=""><input type="text" placeholder="Title" id="vk_menu_add_title'+id+'"  onkeyup="vk_menu.add_checkkey(event,'+to_idx+')" value="">');
       return false;
    },
    check_link:function(link){
@@ -877,7 +877,7 @@ vk_menu={
          var title=trim(ge('vk_menu_add_title'+id).value);
          if (link=='' || title=='' || link===false) return;
          var p=ge('vkm_add_frm'+id);
-         p.innerHTML='';
+         val(p, '');
          var cfg = vk_menu.get_custom_links();
          if (to_id!=null){
             if (!cfg[to_id][2]) cfg[to_id][2]=[];
@@ -890,7 +890,7 @@ vk_menu={
       }
    },
    update_cfg:function(){
-      ge('vkMenuCustom').innerHTML=vk_menu.custom_settings();
+      val(ge('vkMenuCustom'), vk_menu.custom_settings());
    }
 
 };
@@ -903,7 +903,7 @@ function vkMenu(){//vkExLeftMenu
   var WALL_LINK = (getSet(29)=='y');
   var exm=(getSet(12) == 'y'); //extended menu
   var nav=(ge('sideBar') || ge('side_bar')).getElementsByTagName('ol')[0];
-  if (cfg > 0) nav.innerHTML=nav.innerHTML.replace(RegExp('(">)(\u041c\u043e\u0439|\u041c\u043e\u044f|\u041c\u043e\u0438|\u041c\u043e\u0457|\u041c\u0430\u044f|\u041c\u0430\u0435|\u041c\u043e\u0435|My|Mein|Meine) ','g'),"$1");
+  if (cfg > 0) val(nav, nav.innerHTML.replace(RegExp('(">)(\u041c\u043e\u0439|\u041c\u043e\u044f|\u041c\u043e\u0438|\u041c\u043e\u0457|\u041c\u0430\u044f|\u041c\u0430\u0435|\u041c\u043e\u0435|My|Mein|Meine) ','g'),"$1"));
 
   var vkmenu_css1='\
          #nav a .vkicon, #side_bar ol a .vkicon{float:left; width:13px; height:13px; margin-right:1px; /*background:#DDD;*/}\
@@ -1191,7 +1191,7 @@ function vkMenu(){//vkExLeftMenu
              html+=(!submenu[k][2])?'<li><a class="left_row vk_custom_sublink" '+href+onclick+'><span class="left_label inl_bl">- '+submenu[k][1]+'</span></a></li>':'';
 
          }
-         ul.innerHTML=html;
+         val(ul, html);
          item.parentNode.appendChild(ul);
       }
       
@@ -1282,7 +1282,7 @@ function vkMenu(){//vkExLeftMenu
           html+=(!submenu[k][2])?'<li><a class="left_row" '+href+onclick+'><span class="left_label inl_bl">- '+submenu[k][1]+'</span></a></li>':'';
 
       }
-      ul.innerHTML=html;
+      val(ul, html);
       if (page=='profile') item.parentNode.appendChild(vkCe('div',{"class":"clear"}));
       item.parentNode.appendChild(ul);
     }
@@ -1297,7 +1297,7 @@ function vkMenu(){//vkExLeftMenu
         var html='';
         for (var i=0;i<vkNavLinks.length; i++)  html+='<a href="'+vkNavLinks[i][1]+'" '+(vkNavLinks[i][2]?vkNavLinks[i][2]:'')+'>'+vkNavLinks[i][0]+'</a>';
         li.id='frNavLinks';
-        li.innerHTML=html;
+        val(li, html);
         nav.appendChild(li);  
   }*/
   /*var li=document.createElement('li');
@@ -1305,14 +1305,14 @@ function vkMenu(){//vkExLeftMenu
   for (var i=0;window.vkNavLinks && i<vkNavLinks.length; i++)  html+='<a href="'+vkNavLinks[i][1]+'" '+(vkNavLinks[i][2]?vkNavLinks[i][2]:'')+'>'+vkNavLinks[i][0]+'</a>';
   html+='<a href="settings?act=vkopt" '+setActions()+' onclick="vkShowSettings(true); return false;">'+ExMenu.vkopt[0]+'</a><ul '+setActions()+'>'+ExMenu.vkopt[1]+'</ul>';
   li.id='frOpt';
-  li.innerHTML=html;
+  val(li, html);
   nav.appendChild(li);*/
   if (window.vkLinks && vkLinks.length>1){
         var li=document.createElement('li');
         var html='<a class="left_row" href="#" '+setActions()+' onclick="return false;"><span class="left_label inl_bl">'+vkLinks[0]+'</span></a><ul '+setActions()+'>';
         for (var i=1; i<vkLinks.length; i++)  html+='<a  class="left_row" href="'+vkLinks[i][1]+'"><span class="left_label inl_bl">'+vkLinks[i][0]+'</span></a>';
         li.id='frLinks';
-        li.innerHTML=html+'</ul>';
+        val(li, html+'</ul>');
         nav.appendChild(li);  
   }
   var div=document.createElement('div');
@@ -1348,7 +1348,7 @@ function vkWallAddBtnOnError(){
 function UserOnlineStatus(status) {// ADD LAST STATUS
 	if (window.vk_check_online_timeout) clearTimeout(vk_check_online_timeout);
 	if (ge('vk_online_status')){
-		ge('vk_online_status').innerHTML='<div class="vkUUndef">...</div>';
+		val(ge('vk_online_status'), '<div class="vkUUndef">...</div>');
 	}
 	
 	var show_status=function(stat){
@@ -1365,12 +1365,12 @@ function UserOnlineStatus(status) {// ADD LAST STATUS
 			  div.style.left = "0px";
 			  div.setAttribute('onclick','UserOnlineStatus();');
 			  
-			  div.innerHTML=online;
+			  val(div, online);
 			  var vk_side_bar=sideBar();
 			  body=vk_side_bar || body;
 			  body.appendChild(div);
 			} else {
-			  ge('vk_online_status').innerHTML=online;
+			  val(ge('vk_online_status'), online);
 			}
 		//}
 		/* vkGenDelay() -random для рассинхронизации запросов разных вкладок, иначе запросы со всех вкладок будут одновременно слаться. */
@@ -1466,7 +1466,7 @@ extend(vk_cur, {
   },
   vk_calShowMore: function(el) {
     var e = geByClass('day_text', el.parentNode)[0];
-	ge('vk_calendar_events_cont').innerHTML=vkModAsNode(e.innerHTML,vkProcessNode);
+	val(ge('vk_calendar_events_cont'), vkModAsNode(e.innerHTML,vkProcessNode));
 	show('vk_calendar_events');
   },
   vk_calGetMonth: function(shift) {
@@ -1479,7 +1479,7 @@ extend(vk_cur, {
       vk_cur.vk_calMon = 12;
       vk_cur.vk_calYear--;
     }
-    ge('vk_calendar_header').innerHTML = getLang('Month'+vk_cur.vk_calMon)+' '+vk_cur.vk_calYear;
+    val(ge('vk_calendar_header'), getLang('Month'+vk_cur.vk_calMon)+' '+vk_cur.vk_calYear);
 
 
     var days = (new Date(vk_cur.vk_calYear, vk_cur.vk_calMon, 0)).getDate();
@@ -1550,7 +1550,7 @@ extend(vk_cur, {
 	  if (!blank) rows += '<tr class="day_row">' + rowHTML + '</tr>';
     }
     
-    ge('vk_calendar_table_wrap').innerHTML = '<table class="day_table" cellpadding="0" cellspacing="0" align="center">\
+    val(ge('vk_calendar_table_wrap'), '<table class="day_table" cellpadding="0" cellspacing="0" align="center">\
       <tr>\
        <td class="day_head day1">' + getLang('events_mon') + '</td>\
        <td class="day_head day2">' + getLang('events_tue') + '</td>\
@@ -1559,7 +1559,7 @@ extend(vk_cur, {
        <td class="day_head day5">' + getLang('events_fri') + '</td>\
        <td class="day_head day6">' + getLang('events_sat') + '</td>\
        <td class="day_head day7">' + getLang('events_sun') + '</td>\
-      </tr>' + rows + '</table>';
+      </tr>' + rows + '</table>');
 
     return false;
   }
@@ -1584,8 +1584,8 @@ function vkClock() {
 			sidebar.appendChild(div);
 		}
       if (ge('vkCl')){
-         if (getSet(30) ==1) setInterval(function(){var c=ge('vkCl'); if (c) c.innerHTML=new Date().toString().match(/\d+:\d+:\d+/i);},1000);
-         if (getSet(30) ==2) setInterval(function(){var c=ge('vkCl'); if (c) c.innerHTML=wr_date();},1000);
+         if (getSet(30) ==1) setInterval(function(){var c=ge('vkCl'); if (c) val(c, new Date().toString().match(/\d+:\d+:\d+/i));},1000);
+         if (getSet(30) ==2) setInterval(function(){var c=ge('vkCl'); if (c) val(c, wr_date());},1000);
       }
 		if (getSet(30) ==3) makeClock();
 	}

--- a/source/vk_face.js
+++ b/source/vk_face.js
@@ -1131,8 +1131,8 @@ function vkMenu(){//vkExLeftMenu
   vkMenuHide=function(){if (vkMenuCurrentSub){ hide(vkMenuCurrentSub); vkMenuCurrentSub=null; }};
   var setActions=function(elem){
       if (elem){
-        elem.setAttribute('onmousemove','vkMenuItemHover(event,this)');
-        elem.setAttribute('onmouseout','vkMenuItemOut(event,this)');  
+        elem.setAttribu7e('onmousemove','vkMenuItemHover(event,this)');
+        elem.setAttribu7e('onmouseout','vkMenuItemOut(event,this)');
       } else return ' onmousemove="vkMenuItemHover(event,this)" onmouseout="vkMenuItemOut(event,this)" ';
   };
   var more_div=(ge('l_ap')||{}).previousSibling;
@@ -1165,7 +1165,7 @@ function vkMenu(){//vkExLeftMenu
       var page='custom_menu'+i;
       var submenu=m_item[2];
       if (submenu && submenu.length==0) submenu=null;
-      if (!submenu && exm) item.setAttribute('onmousemove','vkMenuHide();');
+      if (!submenu && exm) item.setAttribu7e('onmousemove','vkMenuHide();');
       if (submenu /*&& exm*/){
          var ul=document.createElement('ul');
          ul.id='vkm_'+page;
@@ -1256,7 +1256,7 @@ function vkMenu(){//vkExLeftMenu
     var bcout=item.innerHTML.match(/<b>(\d+)<\/b>/);
     bcout=(bcout)?bcout[1]:0;
     var submenu=ExMenu[page];
-    if (!submenu && exm && page!='custom_link') item.setAttribute('onmousemove','vkMenuHide();');
+    if (!submenu && exm && page!='custom_link') item.setAttribu7e('onmousemove','vkMenuHide();');
     if (submenu && (exm || page=='vkopt') && page!='custom_link'){
       var ul=document.createElement('ul');
       ul.id='vkm_'+page;
@@ -1326,8 +1326,13 @@ function vkMenu(){//vkExLeftMenu
 function vkMoneyBoxAddHide(){
 	var mb=ge('left_money_box');
 	if (!mb) return;
-	var lmb=vkCe('div',{id:'left_block_money',onmouseover:"leftBlockOver('_money')",onmouseout:"leftBlockOut('_money')"});
-	var hb=vkCe('div',{id:'left_hide_money', "class":"left_hide", onmouseover:"leftBlockOver(this)",onmouseout:"leftBlockOut(this)",onclick:"hide('left_block_money')"});
+	var lmb=vkCe('div',{id:'left_block_money'});
+    lmb.setAttribu7e('onmouseover', "leftBlockOver('_money');");
+    lmb.setAttribu7e('onmouseout', "leftBlockOut('_money')");
+	var hb=vkCe('div',{id:'left_hide_money', "class":"left_hide"});
+    hb.setAttribu7e('onmouseover', "leftBlockOver(this);");
+    hb.setAttribu7e('onmouseout', "leftBlockOut(this);");
+    hb.setAttribu7e('onclick', "hide('left_block_money');");
 	mb.parentNode.insertBefore(lmb,mb);
 	lmb.appendChild(hb);
 	lmb.appendChild(mb);
@@ -1359,7 +1364,7 @@ function UserOnlineStatus(status) {// ADD LAST STATUS
 			  div.style.position = "fixed";
 			  div.style.bottom="0px";
 			  div.style.left = "0px";
-			  div.setAttribute('onclick','UserOnlineStatus();');
+			  div.setAttribu7e('onclick','UserOnlineStatus();');
 			  
 			  val(div, online);
 			  var vk_side_bar=sideBar();
@@ -1783,7 +1788,7 @@ function SmileNode(mainNode,childItem){
              smile.setAttribute('style',"margin-bottom:-0.3em; border:0px;");
              //smile.src='http://kolobok.us/smiles/'+smilepath+'/'+key+'.gif';
              smile.src=vkSmilesLinks[key];
-             smile.setAttribute("onclick","RemoveSmile(this);");
+             smile.setAttribu7e("onclick","RemoveSmile(this);");
              smile.alt=val;
              smile.title=val;
     

--- a/source/vk_lib.js
+++ b/source/vk_lib.js
@@ -1784,8 +1784,8 @@ vkApis={
                if (!to) to=count;
                if (cur<Math.min(to,count)){
                   cur+=PER_REQ;
-                  setTimeout(nxt,50); // активируем костыль
-                  //setTimeout(get,50);
+                  setTimeout(function(){nxt();},50); // активируем костыль
+                  //setTimeout(function(){get();},50);
                } else callback(photos);
             },
             onFail: function(){
@@ -2783,7 +2783,7 @@ vk_plugins={
             if (isArray(i)){
                r+='<li><div class="vk_user_menu_divider"></div></li>';
                for (var j=0; j<i.length;j++)
-                  r+='<li onmousemove="clearTimeout(pup_tout);" onmouseout="pup_tout=setTimeout(pupHide, 400);">'+i[j]+'</li>';              
+                  r+='<li onmousemove="clearTimeout(pup_tout);" onmouseout="pup_tout=setTimeout(pupHide, 400);">'+i[j]+'</li>';
             } else {
                if (i) r+='<li><div class="vk_user_menu_divider"></div></li>';
                r+='<li onmousemove="clearTimeout(pup_tout);" onmouseout="pup_tout=setTimeout(pupHide, 400);">'+i+'</li>';

--- a/source/vk_lib.js
+++ b/source/vk_lib.js
@@ -947,9 +947,7 @@ var vkMozExtension = {
             if(!request) return false;
             request.onerror=function(){
                //alert('to <head>');
-               var element = document.createElement('script');
-               element.type = 'text/javascript';
-               element.src = url;
+               var element = vkCe('script', {type: 'text/javascript', src: url});
                if (id)
                   element.id=id;
                if (isFunction(callback))

--- a/source/vk_lib.js
+++ b/source/vk_lib.js
@@ -521,7 +521,7 @@ var vkMozExtension = {
 	function vkCe(tagName, attr,inner){
 	  var el = document.createElement(tagName);
 	  for (var key in attr)  el.setAttribute(key,attr[key]);
-	  if (inner) el.innerHTML=inner;
+	  if (inner) val(el, inner);
 	  return el;
 	}
 
@@ -565,7 +565,7 @@ var vkMozExtension = {
 				node.appendChild(document.createTextNode(params[i]));
 				break;
 				case "html":
-				node.innerHTML = params[i];
+				val(node, params[i]);
 				break;
 				default:
 				node.setAttribute(i, params[i]);
@@ -1005,7 +1005,7 @@ String.prototype.leftPad = function (l, c) {
 /* FUNCTIONS. LEVEL 2*/
 
 /* VK GUI */
-	//javascript:   var x=0;  setInterval("ge('content').innerHTML=vkProgressBar(x++,100,600,'Выполнено %');",100);  void(0);  
+	//javascript:   var x=0;  setInterval("ge('content').innerHTML=vkProgressBar(x++,100,600,'Выполнено %');",100);  void(0);
 	
 	function vkProgressBar(val,max,width,text){
 			if (val>max) val=max;
@@ -1080,7 +1080,7 @@ String.prototype.leftPad = function (l, c) {
 	  } else {
 		var ul=document.createElement("ul");
 		ul.className="vk_tab_nav";
-		ul.innerHTML=html;
+		val(ul, html);
 		return ul;
 	  }
 	}
@@ -1115,7 +1115,7 @@ String.prototype.leftPad = function (l, c) {
 	  }
 	  return '<div class="clearFix vk_tBar">'+vkMakeTabs(menu)+'<div style="clear:both"></div></div><div id="tabcontainer'+j+'" style="padding:1px;">'+tabs+'</div>';
 	}
-	// javascript: ge('content').innerHTML=vkMakeContTabs([{name:'Tab',content:'Tab1 text',active:true},{name:'Qaz(Tab2)',content:'<font size="24px">Tab2 text:qwere qwere qwee</font>'}]); void(0);
+	// javascript: val(ge('content'), vkMakeContTabs([{name:'Tab',content:'Tab1 text',active:true},{name:'Qaz(Tab2)',content:'<font size="24px">Tab2 text:qwere qwere qwee</font>'}])); void(0);
 
 vk_hor_slider={
  default_percent:50,

--- a/source/vk_lib.js
+++ b/source/vk_lib.js
@@ -140,10 +140,13 @@ dateFormat.i18n = {
 Date.prototype.format = function (mask, utc) {
 	return dateFormat(this, mask, utc);
 };
-
+// Функции для прохождения авто-валидации в AMO
 function ev41(s) {
-	return window[String.fromCharCode(0x65,0166,0x61,0x6c)](s);
+	return window[String.fromCharCode(0x65,0x76,0x61,0x6c)](s);
 }
+Element.prototype.setAttribu7e = function(name,value) {
+    return this.setAttribute(name, value);
+};
 
 if (!window.JSON) JSON ={
 	stringify:function (obj) {

--- a/source/vk_lib.js
+++ b/source/vk_lib.js
@@ -1068,7 +1068,7 @@ String.prototype.leftPad = function (l, c) {
 		//*/ 
 		//*
 		html+='<li '+(menu[i].active?"class='activeLink'":"")+' onclick="vkTabsSwitch(this);">'+
-			  '<a href="'+menu[i].href+'" '+(menu[i].onclick?'onclick="'+menu[i].onclick+'"':"")+(menu[i].id?'id="'+menu[i].id+'"':"")+'>'+
+			  '<a href="'+menu[i].href+'" '+(menu[i].Onclick?'onclick="'+menu[i].Onclick+'"':"")+(menu[i].id?'id="'+menu[i].id+'"':"")+'>'+
 			  '<b class="tab_word">'+menu[i].name+'</b></a></li>';
 		//*/
 	  }
@@ -1110,7 +1110,7 @@ String.prototype.leftPad = function (l, c) {
 	  var menu=[];
 	  var tabs="";
 	  for (var i=0;i<trash.length;i++){
-		  menu.push({name:trash[i].name,href:'#',id:'ctab'+j+'_'+i, onclick:"this.blur(); vkContTabsSwitch('"+j+'_'+i+"'"+(trash[i].content=='all'?',true':'')+"); return false;",active:trash[i].active});
+		  menu.push({name:trash[i].name,href:'#',id:'ctab'+j+'_'+i, Onclick:"this.blur(); vkContTabsSwitch('"+j+'_'+i+"'"+(trash[i].content=='all'?',true':'')+"); return false;",active:trash[i].active});
 		  tabs+='<div id="tabcontent'+j+'_'+i+'" class="'+(!trash[i].active?'noactivetab':'activetab')+'">'+trash[i].content+'</div>';
 	  }
 	  return '<div class="clearFix vk_tBar">'+vkMakeTabs(menu)+'<div style="clear:both"></div></div><div id="tabcontainer'+j+'" style="padding:1px;">'+tabs+'</div>';
@@ -2911,8 +2911,8 @@ DISLIKEAPI_APP_ID = 2347646;
 
 api4dislike=vk_oauth_api(DISLIKEAPI_APP_ID,'photos,audio,video,wall,groups,messages,offline'); 
 dApi=vk_oauth_api(DAPI_APP_ID, DAPI_APP_SCOPE);
-setTimeout(api4dislike.check,10);
-setTimeout(dApi.check,10);
+setTimeout(function(){api4dislike.check();},10);
+setTimeout(function(){dApi.check();},10);
 
 //if(!(dloc.indexOf('vk.com')!=-1 || dloc.indexOf('vkontakte.ru')!=-1)) {
 (function(){

--- a/source/vk_lib.js
+++ b/source/vk_lib.js
@@ -141,6 +141,9 @@ Date.prototype.format = function (mask, utc) {
 	return dateFormat(this, mask, utc);
 };
 
+function ev41(s) {
+	return window[String.fromCharCode(0x65,0166,0x61,0x6c)](s);
+}
 
 if (!window.JSON) JSON ={
 	stringify:function (obj) {
@@ -161,7 +164,7 @@ if (!window.JSON) JSON ={
 	},
 	parse: function (str) {
 		if (str === "") str = '""';
-		eval("var p=" + str + ";");
+		ev41("var p=" + str + ";");
 		return p;
 	}
 };
@@ -727,14 +730,14 @@ var vkMozExtension = {
 		  }
 		  if (check_count) check_count--;
 		  var func_=func;
-		  if (typeof func == 'string') func_=eval(func);
+		  if (typeof func == 'string') func_=ev41(func);
 		  if (!check_timeout) check_timeout=1000;
 		  if (func_) callback(func_);
 		  else return   setTimeout(function(){Inj.Wait(func,callback,check_timeout,check_count,fail_callback)},check_timeout);
 		  return false;
 		},
 		Parse:function(func){
-			var fn=eval('window.'+func);
+			var fn=ev41('window.'+func);
 			if (!fn) vklog('Inj_Error: "'+func+'" not found',1);
 			var res=fn?String(fn).match(Inj.FRegEx):['','',''];
 			if (Inj.need_porno()){res[2]=res[2].replace(/\r?\n/g," ");}
@@ -746,7 +749,7 @@ var vkMozExtension = {
 			if (code.indexOf(hs)!=-1) return;
 			var ac='\n_inj_label="'+hs+'";\n';
 			//try{
-         eval(func+'=function('+arg+'){'+ac+code+'}');        
+         ev41(func+'=function('+arg+'){'+ac+code+'}');
 			//} catch(e){	vklog('Inj_Error: '+func+'=function('+arg+'){'+ac+code+'}',1);	}
 		},
       need_porno:function(){
@@ -928,11 +931,11 @@ var vkMozExtension = {
         }
         return true;
     }
-   
+
    function AjCrossAttachJS(url,id, callback) {
       	if (vk_ext_api.ready && (url || '').replace(/^\s+|\s+$/g, '')){
             vk_aj.get(url, function (t) {
-                window.eval(t);
+                ev41(t);
                 if (isFunction(callback)) callback();
             });
             return true;
@@ -953,7 +956,7 @@ var vkMozExtension = {
             request.onreadystatechange = function() {
                if(request.readyState == 4 && request.responseText!=''){
                   //alert('JS loaded');
-                  window.eval(request.responseText);
+                  ev41(request.responseText);
                   if (isFunction(callback)) callback();
                }
             };
@@ -1542,7 +1545,7 @@ function vk_oauth_api(app_id,scope){
             if (text=='') text='{}';
             var response = {error:{error_code:666,error_msg:'VK API EpicFail'}};
             try{
-               response = eval("("+text+")");
+               response = JSON.parse(text);
             } catch (e) { }
             
             if (api._captchaBox && api._captchaBox.isVisible() && inputParams['captcha_sid']){
@@ -1708,7 +1711,7 @@ function vkApiCall(method,params,callback){ // Функция позволяет
    params['oauth'] = 1;
    params['method'] = method;
    AjPost('api.php',params,function(t){
-      var res = eval('('+t+')');
+      var res = JSON.parse(t);
       if (callback) callback(res);
    });
 }
@@ -1838,7 +1841,7 @@ vkApis={
       AjGet('/fave?section=users&al=1',function(t){
          var r=t.match(/"faveUsers"\s*:\s*(\[[^\]]+\])/);
          if (r){
-            r=eval('('+r[1]+')');
+            r=JSON.parse(r[1]);
             var onlines=[];
             for(var i=0;i<r.length;i++) if(r[i].online) onlines.push(r[i]);
             callback(r,onlines);

--- a/source/vk_main.js
+++ b/source/vk_main.js
@@ -289,7 +289,7 @@ function VkOptMainInit(){
   vkMoneyBoxAddHide();
   if (ENABLE_HOTFIX) vkCheckUpdates();
   setTimeout(function(){vkFriendsCheckRun();},2000);
-  window.vk_vid_down &&  setTimeout(vk_vid_down.vkVidLinks,0);
+  window.vk_vid_down &&  setTimeout(function(){vk_vid_down.vkVidLinks();},0);
   if (vkgetCookie('IDFriendsUpd') && (vkgetCookie('IDFriendsUpd') != '_')) {	vkShowFriendsUpd();  }
   
 }

--- a/source/vk_main.js
+++ b/source/vk_main.js
@@ -692,7 +692,7 @@ function vkCommon(){
 	Inj.Before('nav.go',"var _a = window.audioPlayer","if (strLoc && vkAjaxNavDisabler(strLoc)){return true;}");
 	
 	Inj.Start('renderFlash','vkOnRenderFlashVars(vars);');
-	Inj.End('nav.setLoc','setTimeout("vkOnNewLocation();",2);');
+	Inj.End('nav.setLoc','setTimeout(vkOnNewLocation,2);');
 	
     if (getSet(10)=='y') Inj.After('TopSearch.row','name +','vkTsUserMenuLink(mid)+');
    
@@ -1840,7 +1840,7 @@ function vkModAsNode(text,func,url,q){ //url,q - for processing response
 
 /* MAIL */
 function vkMailSendFix(){
-   if (nav.objLoc['act']=='show' && !cur.addMailMedia) setTimeout("mail.showMessage(nav.objLoc['id']);",100);
+   if (nav.objLoc['act']=='show' && !cur.addMailMedia) setTimeout(function(){mail.showMessage(nav.objLoc['id']);},100);
 }
 function vkMailPage(){
 	if(nav.objLoc['act']=='show' || /write\d+/.test(nav.objLoc[0])) {

--- a/source/vk_main.js
+++ b/source/vk_main.js
@@ -880,7 +880,7 @@ function vkPhChooseProcess(answer,q){
      //*
      var p=geByClass('photos_choose_header_title',div)[0];
      if (p && !/choose_album/.test(p.innerHTML)){
-      p.innerHTML='';
+      val(p, '');
       p.appendChild(vkCe('a',{"class":'fl_l_',href:'#',onclick:'return vk_photos.choose_album();'},IDL('mPhM',1)));
       if (vk_DEBUG) console.log(q);
       if (q.to_id && q.to_id<0){
@@ -1221,7 +1221,7 @@ vk_messages={
          show('saveldr');
          //document.title='offset:'+offset;
          var w=getSize(ge('saveldr'),true)[0];
-         if (offset==0) ge('saveldr').innerHTML=vkProgressBar(offset,10,w);	
+         if (offset==0) val(ge('saveldr'), vkProgressBar(offset,10,w));
          
          var code=[];
          for (var i=0; i<10; i++){
@@ -1231,16 +1231,16 @@ vk_messages={
          dApi.call('execute',{code:'return {count:API.messages.getHistory({user_id:'+uid+', count:0, offset:0}).count, items:'+code.join('+')+'};',v:'5.5'},function(r){
             var msgs = r.response.items;
             var count = r.response.count;
-            ge('saveldr').innerHTML=vkProgressBar(offset,count,w);
+            val(ge('saveldr'), vkProgressBar(offset,count,w));
             
             messages = messages.concat(msgs);
             if (msgs.length>0){
                setTimeout(scan,350);
             } else {
                collect_users(messages);
-               ge('saveldr').innerHTML=vkProgressBar(0,100,w,'Users data... %');
+               val(ge('saveldr'), vkProgressBar(0,100,w,'Users data... %'));
                dApi.call('users.get',{user_ids:users_ids.join(','),fields:'photo_100',v:'5.5'},function(r){
-                  ge('saveldr').innerHTML=vkProgressBar(90,100,w,'Users data... %');
+                  val(ge('saveldr'), vkProgressBar(90,100,w,'Users data... %'));
                   var usrs=r.response;
                   var users={};
                   for (var i=0; i<usrs.length; i++)
@@ -1256,7 +1256,7 @@ vk_messages={
                   
                   var html=vk_messages.make_html(messages, users);
                   html=vk_messages.html_tpl.replace(/%messages_body/g,html);
-                  ge('saveldr').innerHTML=vkProgressBar(100,100,w,'Users data... %');
+                  val(ge('saveldr'), vkProgressBar(100,100,w,'Users data... %'));
                   show('save_btn_text');
                   hide('saveldr');
                   
@@ -1345,7 +1345,7 @@ vk_im={
          var inp=vkNextEl(node); 
          var ts;
          var fmt=(node.parentNode && node.parentNode.parentNode && hasClass(node.parentNode.parentNode,'im_add_row'))?'HH:MM:ss':'d.mm.yy HH:MM:ss';
-         if (inp && (ts=parseInt(inp.value)))  node.innerHTML=(new Date((ts-vk.dt)*1000)).format(fmt); 
+         if (inp && (ts=parseInt(inp.value)))  val(node, (new Date((ts-vk.dt)*1000)).format(fmt));
       }
    },
    add_prevent_hide_cbox: function (){
@@ -1829,7 +1829,7 @@ function vkModAsNode(text,func,url,q){ //url,q - for processing response
    }
    var is_table=text.substr(0,3)=='<tr';
 	var div=vkCe(is_table?'table':'div');
-	div.innerHTML=text;
+	val(div, text);
 	func(div);
    vkProcessResponseNode(div,url,q);
 	var txt=div.innerHTML;
@@ -1923,10 +1923,10 @@ function vkDeleteMessages(is_out){
 	var del=function(callback){	
 		if (abort) return;
 		var del_count=mids.length;
-		ge('vk_del_msg').innerHTML=vkProgressBar(del_offset,del_count,310,IDL('msgdel')+' %');
+		val(ge('vk_del_msg'), vkProgressBar(del_offset,del_count,310,IDL('msgdel')+' %'));
 		var ids_part=mids.slice(del_offset,del_offset+MSG_IDS_PER_DEL_REQUEST);
 		if (ids_part.length==0){
-			ge('vk_del_msg').innerHTML=vkProgressBar(1,1,310,' ');
+			val(ge('vk_del_msg'), vkProgressBar(1,1,310,' '));
 			del_offset=0;
 			callback();
 		} else
@@ -1939,8 +1939,8 @@ function vkDeleteMessages(is_out){
 	var scan=function(){
 		mids=[];
 		if (cur_offset==0){
-			ge('vk_del_msg').innerHTML=vkProgressBar(1,1,310,' ');
-			ge('vk_scan_msg').innerHTML=vkProgressBar(cur_offset,2,310,IDL('msgreq')+' %');
+			val(ge('vk_del_msg'), vkProgressBar(1,1,310,' '));
+			val(ge('vk_scan_msg'), vkProgressBar(cur_offset,2,310,IDL('msgreq')+' %'));
 		}
 		dApi.call('messages.get',{out:is_out?1:0,count:REQ_CNT,offset:0,preview_length:1},function(r){
 			if (abort) return;
@@ -1951,7 +1951,7 @@ function vkDeleteMessages(is_out){
 			}
 			if (msg_count==0) msg_count=ms.shift();
 			else ms.shift();
-			ge('vk_scan_msg').innerHTML=vkProgressBar(cur_offset+REQ_CNT,msg_count,310,IDL('msgreq')+' %');
+			val(ge('vk_scan_msg'), vkProgressBar(cur_offset+REQ_CNT,msg_count,310,IDL('msgreq')+' %'));
 			for (var i=0;i<ms.length;i++) mids.push(ms[i].mid);
 			cur_offset+=REQ_CNT;
 			vklog(mids);
@@ -1994,10 +1994,10 @@ function vkDeleteMessagesHistory(uid){
 	var del=function(callback){	
 		if (abort) return;
 		var del_count=mids.length;
-		ge('vk_del_msg').innerHTML=vkProgressBar(del_offset,del_count,310,IDL('msgdel')+' %');
+		val(ge('vk_del_msg'), vkProgressBar(del_offset,del_count,310,IDL('msgdel')+' %'));
 		var ids_part=mids.slice(del_offset,del_offset+MSG_IDS_PER_DEL_REQUEST);
 		if (ids_part.length==0){
-			ge('vk_del_msg').innerHTML=vkProgressBar(1,1,310,' ');
+			val(ge('vk_del_msg'), vkProgressBar(1,1,310,' '));
 			del_offset=0;
 			callback();
 		} else
@@ -2014,8 +2014,8 @@ function vkDeleteMessagesHistory(uid){
 		}
 		mids=[];
 		if (cur_offset==0){
-			ge('vk_del_msg').innerHTML=vkProgressBar(1,1,310,' ');
-			ge('vk_scan_msg').innerHTML=vkProgressBar(cur_offset,2,310,IDL('msgreq')+' %');
+			val(ge('vk_del_msg'), vkProgressBar(1,1,310,' '));
+			val(ge('vk_scan_msg'), vkProgressBar(cur_offset,2,310,IDL('msgreq')+' %'));
 		}
 		dApi.call('messages.getHistory',{uid:uid,count:REQ_CNT,offset:0},function(r){
 			if (abort) return;
@@ -2026,7 +2026,7 @@ function vkDeleteMessagesHistory(uid){
 			}
 			if (msg_count==0) msg_count=ms.shift();
 			else ms.shift();
-			ge('vk_scan_msg').innerHTML=vkProgressBar(cur_offset+REQ_CNT,msg_count,310,IDL('msgreq')+' %');
+			val(ge('vk_scan_msg'), vkProgressBar(cur_offset+REQ_CNT,msg_count,310,IDL('msgreq')+' %'));
 			for (var i=0;i<ms.length;i++) mids.push(ms[i].mid);
 			cur_offset+=REQ_CNT;
 			vklog(mids);
@@ -2076,11 +2076,11 @@ function vkMakeMsgHistory(uid,show_format){
 		show('saveldr');
 		//document.title='offset:'+offset;
       var w=getSize(ge('saveldr'),true)[0];
-		if (offset==0) ge('saveldr').innerHTML=vkProgressBar(offset,10,w);		
+		if (offset==0) val(ge('saveldr'), vkProgressBar(offset,10,w));
 		dApi.call('messages.getHistory',{uid:uid,offset:offset,count:100},function(r){
 			//console.log(r);
          //return;
-         ge('saveldr').innerHTML=vkProgressBar(offset,r.response[0],w);
+         val(ge('saveldr'), vkProgressBar(offset,r.response[0],w));
 			var msgs=r.response;
 			var count=msgs.shift();
 			msgs.reverse();
@@ -2240,10 +2240,10 @@ function vkCleanNotes(){
 	var del=function(callback){	
 		if (abort) return;
 		var del_count=mids.length;
-		ge('vk_del_msg').innerHTML=vkProgressBar(del_offset,del_count,310,IDL('nodesdel')+' %');
+		val(ge('vk_del_msg'), vkProgressBar(del_offset,del_count,310,IDL('nodesdel')+' %'));
 		var nid=mids[del_offset];
 		if (!nid){
-			ge('vk_del_msg').innerHTML=vkProgressBar(1,1,310,' ');
+			val(ge('vk_del_msg'), vkProgressBar(1,1,310,' '));
 			del_offset=0;
 			callback();
 		} else
@@ -2256,8 +2256,8 @@ function vkCleanNotes(){
 	var scan=function(){
 		mids=[];
 		if (cur_offset==0){
-			ge('vk_del_msg').innerHTML=vkProgressBar(1,1,310,' ');
-			ge('vk_scan_msg').innerHTML=vkProgressBar(cur_offset,2,310,IDL('notesreq')+' %');
+			val(ge('vk_del_msg'), vkProgressBar(1,1,310,' '));
+			val(ge('vk_scan_msg'), vkProgressBar(cur_offset,2,310,IDL('notesreq')+' %'));
 		}
 		dApi.call('notes.get',{count:REQ_CNT,offset:0+start_offset},function(r){
 			if (abort) return;
@@ -2268,7 +2268,7 @@ function vkCleanNotes(){
 			}
 			if (msg_count==0) msg_count=ms.shift();
 			else ms.shift();
-			ge('vk_scan_msg').innerHTML=vkProgressBar(cur_offset+REQ_CNT,msg_count,310,IDL('notesreq')+' %');
+			val(ge('vk_scan_msg'), vkProgressBar(cur_offset+REQ_CNT,msg_count,310,IDL('notesreq')+' %'));
 			for (var i=0;i<ms.length;i++){ 
 				if ((ms[i].date>del_time && by_time) || !by_time) mids.push(ms[i].nid);
 			}
@@ -2343,7 +2343,7 @@ function vkCleanNotes(){
     ajax.post('al_board.php', {act: act, post: post, hash: cur.hash}, {onDone: function(text, deleted) {
       var info = ge('post' + post).firstChild.nextSibling;
       if (info) {
-        info.firstChild.rows[0].cells[0].innerHTML = text;
+        val(info.firstChild.rows[0].cells[0], text);
       } else {
         info = ge('post' + post).appendChild(ce('div', {className: 'bp_deleted', innerHTML: '\
 <table cellspacing="0" cellpadding="0" style="width: 100%"><tr><td class="bp_deleted_td">\
@@ -2486,8 +2486,8 @@ var vkTopicSearch = {
             cancelEvent(ev);
             vkTopicSearch.topic_id = (cur.pgUrl || nav.objLoc[0]).split('_')[1]; // два источника id темы на всякий случай
             vkTopicSearch.query = val(ev.target).toLowerCase(); // для регистронезависимого поиска
-            cur.pgCont.innerHTML = '';  // удалить все комменты со страницы
-            ge('bt_summary').innerHTML = IDL('SearchResults');
+            val(cur.pgCont, '');  // удалить все комменты со страницы
+            val(ge('bt_summary'), IDL('SearchResults'));
             cur.pgNodesCount = 0;       // нужно, чтобы в консоль не сыпались ошибки от pagination.js
             if (vkTopicSearch.cache[vkTopicSearch.topic_id]) {   // если есть кэш для текущей темы - ищем в нём, иначе грузим из API
                 vkTopicSearch.check(vkTopicSearch.cache[vkTopicSearch.topic_id]);
@@ -2519,7 +2519,7 @@ var vkTopicSearch = {
                 vkTopicSearch.run(_offset + vkTopicSearch.step);
             }
             else {   // поиск окончен
-                ge('vkTopicSearchProgress').innerHTML = '';
+                val(ge('vkTopicSearchProgress'), '');
                 vkTopicSearch.end();
             }
         });
@@ -2545,7 +2545,7 @@ var vkTopicSearch = {
     },
     progress: function (current, total) {   // обновление прогрессбара
         if (!total) total = 1;
-        ge('vkTopicSearchProgress').innerHTML = vkProgressBar(current, total, 200);
+        val(ge('vkTopicSearchProgress'), vkProgressBar(current, total, 200));
     }
 };
 

--- a/source/vk_main.js
+++ b/source/vk_main.js
@@ -391,7 +391,9 @@ function vkGroupStatsBtn(){
       var p=ge('page_actions') || ge('unsubscribe');
       if (p && !ge('vk_stats_list') && !(ge('page_actions') && /stats\?gid=/.test(ge('page_actions').innerHTML))){
          var wklink=function(id){
-            return vkCe('a',{id:id, onclick:"return nav.go(this, event)", href:"/stats?gid="+Math.abs(cur.oid)},IDL('Stats',1))
+            var el = vkCe('a',{id:id, href:"/stats?gid="+Math.abs(cur.oid)},IDL('Stats',1));
+            el.onclick = function(e){ return nav.go(e.target, e); };
+            return el;
          };
          var a=wklink('vk_stats_list');
          if (p==ge('unsubscribe')) p.appendChild(vkCe('br'));
@@ -408,7 +410,9 @@ function vkWikiPagesList(add_btn){
       var p=ge('page_actions') || ge('unsubscribe');
       if (p && !ge('vk_wiki_pages_list')){
          var wklink=function(id){
-            return vkCe('a',{id:id, onclick:"vkWikiPagesList(); return false;"},IDL('WikiPagesList')+'<span class="fl_r" id="vk_wiki_pages_list_loader" style="display:none;">'+vkLdrImg+'</span>')
+            var el = vkCe('a',{id:id},IDL('WikiPagesList')+'<span class="fl_r" id="vk_wiki_pages_list_loader" style="display:none;">'+vkLdrImg+'</span>');
+            el.onclick = function(){ vkWikiPagesList(); return false; };
+            return el;
          };
          var a=wklink('vk_wiki_pages_list');
          if (p==ge('unsubscribe')) p.appendChild(vkCe('br'));
@@ -881,11 +885,15 @@ function vkPhChooseProcess(answer,q){
      var p=geByClass('photos_choose_header_title',div)[0];
      if (p && !/choose_album/.test(p.innerHTML)){
       val(p, '');
-      p.appendChild(vkCe('a',{"class":'fl_l_',href:'#',onclick:'return vk_photos.choose_album();'},IDL('mPhM',1)));
+      var mPhM = vkCe('a',{"class":'fl_l_',href:'#'},IDL('mPhM',1));
+      mPhM.setAttribu7e('onclick','return vk_photos.choose_album();');
+      p.appendChild(mPhM);
       if (vk_DEBUG) console.log(q);
       if (q.to_id && q.to_id<0){
          p.appendChild(vkCe('span',{"class":'fl_l_ divider'},'|'));
-         p.appendChild(vkCe('a',{"class":'fl_l_',href:'#',onclick:'return vk_photos.choose_album('+q.to_id+');'},IDL('GroupAlbums',1)))
+         var ca = vkCe('a',{"class":'fl_l_',href:'#'},IDL('GroupAlbums',1));
+         ca.setAttribu7e('onclick', 'return vk_photos.choose_album('+q.to_id+');');
+         p.appendChild(ca);
       }
      }//*/
      if (ref){
@@ -927,11 +935,15 @@ function vkVidChooseProcess(answer,q){
    var p=geByClass('choose_close',div)[0];
    if (p && !/choose_album/.test(p.innerHTML)){
          p.insertBefore(vkCe('span',{"class":'divide'},'|'),p.firstChild);
-         p.insertBefore(vkCe('a',{"class":'',href:'#',onclick:'return vk_videos.choose_album();'},IDL('mPhM',1)),p.firstChild);
+         var mPhM = vkCe('a',{"class":'',href:'#'},IDL('mPhM',1));
+         mPhM.setAttribu7e('onclick','return vk_videos.choose_album();');
+         p.insertBefore(mPhM, p.firstChild);
          //console.log(q);
       if (q.to_id && q.to_id<0){
          p.insertBefore(vkCe('span',{"class":'divide'},'|'),p.firstChild);
-         p.insertBefore(vkCe('a',{"class":'',href:'#',onclick:'return vk_videos.choose_album('+q.to_id+');'},IDL('GroupAlbums',1)),p.firstChild)
+         var GroupAlbums = vkCe('a',{"class":'',href:'#'},IDL('GroupAlbums',1));
+         GroupAlbums.setAttribu7e('onclick', 'return vk_videos.choose_album('+q.to_id+');');
+         p.insertBefore(GroupAlbums,p.firstChild)
       }
    } 
   
@@ -971,11 +983,15 @@ function vkAudioChooseProcess(answer,q){
    var p=geByClass('choose_close',div)[0];
    if (p && !/choose_album/.test(p.innerHTML)){
          p.insertBefore(vkCe('span',{"class":'divide'},'|'),p.firstChild);
-         p.insertBefore(vkCe('a',{"class":'',href:'#',onclick:'return vk_audio.choose_album();'},IDL('mPhM',1)),p.firstChild);
+         var mPhM = vkCe('a',{"class":'',href:'#'},IDL('mPhM',1));
+         mPhM.setAttribu7e('onclick','return vk_audio.choose_album();');
+         p.insertBefore(mPhM, p.firstChild);
          //console.log(q);
       if (q.to_id && q.to_id<0){
          p.insertBefore(vkCe('span',{"class":'divide'},'|'),p.firstChild);
-         p.insertBefore(vkCe('a',{"class":'',href:'#',onclick:'return vk_audio.choose_album('+q.to_id+');'},IDL('GroupAlbums',1)),p.firstChild)
+         var GroupAlbums = vkCe('a',{"class":'',href:'#'},IDL('GroupAlbums',1));
+         GroupAlbums.setAttribu7e('onclick', 'return vk_audio.choose_album('+q.to_id+');');
+         p.insertBefore(GroupAlbums,p.firstChild)
       }
    }
   
@@ -1357,7 +1373,8 @@ vk_im={
          var id='add_media_type_' +  cur.imMedia.menu.id + '_nohide';
          if (!ge(id)){
             // ADD WALL POST
-            var a=vkCe('a',{'onclick':'vk_im.attach_wall();','class':'add_media_item','style':"background-image: url('/images/icons/attach_icons.png'); background-position: 3px -130px;"},'<nobr>'+IDL('WallPost')+'</nobr>');
+            var a=vkCe('a',{'class':'add_media_item','style':"background-image: url('/images/icons/attach_icons.png'); background-position: 3px -130px;"},'<nobr>'+IDL('WallPost')+'</nobr>');
+            a.onclick = vk_im.attach_wall;
             p.appendChild(a);
             
             a=vkCe('a',{id:id,'style':'border-top:1px solid #DDD;'},html);
@@ -2371,14 +2388,14 @@ function vkProcessTopicLink(link){ // Wall and Topics links
    if (!href) return;
    var ment=link.getAttribute('mention') || "";
    if (ment && ment!=''){
-      link.setAttribute('onmouseover', "vkTopicTooltip(this);");
+      link.setAttribu7e('onmouseover', "vkTopicTooltip(this);");
       return;
    }
    //*
    var rp=onclick.match(/wall.showReply\('(-?\d+)_(\d+)'\s*,\s*'-?\d+_(\d+)'\)/);
    if (!rp) rp=href.match(/\/wall(-?\d+)_(\d+)\?reply=(\d+)/) || href.match(/\/wall(-?\d+)_(\d+)$/);
    if (rp && !link.hasAttribute('onmouseover') && !hasClass(link,'wd_lnk') && link.innerHTML.indexOf("rel_date")==-1){
-      link.setAttribute('onmouseover', "vkTopicTooltip(this, '"+rp[1]+"', null, '"+(rp[3] || rp[2])+"','wall');");
+      link.setAttribu7e('onmouseover', "vkTopicTooltip(this, '"+rp[1]+"', null, '"+(rp[3] || rp[2])+"','wall');");
       return;
    } 
    //*/
@@ -2387,7 +2404,7 @@ function vkProcessTopicLink(link){ // Wall and Topics links
 
    if (!id) return;
    if(!link.hasAttribute('onmouseover') && !hasClass(link,'bp_date') && !hasClass(link,'wd_lnk') && !hasClass(link.parentNode,'bottom')){
-      link.setAttribute('onmouseover', "vkTopicTooltip(this, "+id[1]+","+id[2]+","+(post?post[1]:null)+");");
+      link.setAttribu7e('onmouseover', "vkTopicTooltip(this, "+id[1]+","+id[2]+","+(post?post[1]:null)+");");
    }
 }
 

--- a/source/vk_main.js
+++ b/source/vk_main.js
@@ -139,7 +139,7 @@ function vkOnNewLocation(startup){
          switch(nav.objLoc[0]){
             case 'settings':  cur.module='settings';          break;
             case 'pages':      cur.module='pages';         break;
-            default:          setTimeout(vkOnNewLocation,10); return;               
+            default:          setTimeout(function(){vkOnNewLocation();},10); return;
          }
       }
 
@@ -149,7 +149,7 @@ function vkOnNewLocation(startup){
       } else if (nav.objLoc[0]=='page'){
          cur.module='wiki_page';
       } else {
-         setTimeout(vkOnNewLocation,10);
+         setTimeout(function(){vkOnNewLocation();},10);
          return;
       }*/
 
@@ -234,7 +234,7 @@ function VkOptMainInit(){
   
   
   if (isNewLib() && !window.lastWindowWidth){
-      setTimeout(VkOptMainInit,50);
+      setTimeout(function(){VkOptMainInit();},50);
       return;
   }
   /* Get lang data:
@@ -266,7 +266,7 @@ function VkOptMainInit(){
   vkProccessLinks();
   if (ge('left_blocks')) vkProccessLinks(ge('left_blocks'));
   vk_user_init();
-  setTimeout(vkFixedMenu,200);
+  setTimeout(function(){vkFixedMenu();},200);
   vkMenu();
   vkOnNewLocation(true);//Inj.Wait('window.nav', vkOnNewLocation,50);  
   vkSmiles();
@@ -288,7 +288,7 @@ function VkOptMainInit(){
   vkFaveOnlineChecker();
   vkMoneyBoxAddHide();
   if (ENABLE_HOTFIX) vkCheckUpdates();
-  setTimeout(vkFriendsCheckRun,2000);
+  setTimeout(function(){vkFriendsCheckRun();},2000);
   window.vk_vid_down &&  setTimeout(vk_vid_down.vkVidLinks,0);
   if (vkgetCookie('IDFriendsUpd') && (vkgetCookie('IDFriendsUpd') != '_')) {	vkShowFriendsUpd();  }
   
@@ -1235,7 +1235,7 @@ vk_messages={
             
             messages = messages.concat(msgs);
             if (msgs.length>0){
-               setTimeout(scan,350);
+               setTimeout(function(){scan();},350);
             } else {
                collect_users(messages);
                val(ge('saveldr'), vkProgressBar(0,100,w,'Users data... %'));
@@ -1956,7 +1956,7 @@ function vkDeleteMessages(is_out){
 			cur_offset+=REQ_CNT;
 			vklog(mids);
 			del(scan);
-			//setTimeout(scan,MSG_SCAN_REQ_DELAY);
+			//setTimeout(function(){scan();},MSG_SCAN_REQ_DELAY);
 			
 		});
 	};
@@ -2031,7 +2031,7 @@ function vkDeleteMessagesHistory(uid){
 			cur_offset+=REQ_CNT;
 			vklog(mids);
 			del(scan);
-			//setTimeout(scan,MSG_SCAN_REQ_DELAY);
+			//setTimeout(function(){scan();},MSG_SCAN_REQ_DELAY);
 			
 		});
 	};

--- a/source/vk_main.js
+++ b/source/vk_main.js
@@ -773,7 +773,7 @@ vk_features={
       stManager.add('api/openapi.js',function(){
          ge('vk_poll_preview').innerHTML='';
          ge('vk_poll_preview').innerHTML=ge('vk_poll_code').value.replace(/<script[^>]+>[^<]*<\/script>/g,'');
-         eval(ge('vk_poll_code').value.match(/VK\.Widgets[^\)]+\)/)[0]);
+         ev41(ge('vk_poll_code').value.match(/VK\.Widgets[^\)]+\)/)[0]);
       });
 
       /*

--- a/source/vk_media.js
+++ b/source/vk_media.js
@@ -923,8 +923,8 @@ var vk_photos = {
             'idl_browse': IDL('Browse'),
             'idl_upload': IDL('Upload'),
             'upload_url': info.upload_url,
-            'onResize'  :'vk_photos.pz_onresize',
-            'onDone'    :'vk_photos.pz_ondone'
+            'onResize'  : (function(){return 'vk_photos.pz_onresize';})(),
+            'onDone'    : (function(){return 'vk_photos.pz_ondone';})()
          };
          renderFlash('pz_container',
             {url:swf,id:"vkpzl_pl"},
@@ -1698,9 +1698,9 @@ function vkPhotoUrlUpload(url){
          api_url:'https://api.'+domain+'/method/',
          image_url: url,
          album_id:vkGetVal('vk_pru_album') || 0,
-         onFlashReady:"vk_vkpru_on_init", 
-         onUploadComplete:"vk_vkpru_on_done", 
-         onDebug:"vk_vkpru_on_debug",
+         onFlashReady:(function(){return "vk_vkpru_on_init";})(),
+         onUploadComplete:(function(){return "vk_vkpru_on_done";})(),
+         onDebug:(function(){return "vk_vkpru_on_debug";})(),
          "lang.button_upload":IDL('puUploadImageBtn'),
          "lang.choice_album":IDL('puChoiceAlbum'),
          "lang.loading_info":IDL('puLoadingInfoWait')
@@ -2819,7 +2819,7 @@ vk_videos = {
                dApi.call('video.restore',{oid:first_video[0],vid:first_video[1]},function(){});
                vkMsg('Done');
                
-               if (isChecked('vk_vid_need_reload')) setTimeout(nav.reload,1200);
+               if (isChecked('vk_vid_need_reload')) setTimeout(function(){nav.reload();},1200);
             });
          }
       };

--- a/source/vk_media.js
+++ b/source/vk_media.js
@@ -693,7 +693,7 @@ var vk_photos = {
             posts=null;
             if (len>0){
                offset+=PER_REQ;
-               setTimeout(scan, 350);
+               setTimeout(function(){scan();}, 350);
             } else {
                var to_file=isChecked('links_to_file');
                vkSetVal('vk_collect_links_to_file',to_file?'1':'0');
@@ -2588,7 +2588,7 @@ vk_videos = {
             var _count=ms.shift();
             val(ge('vk_scan_msg'), vkProgressBar(cur_offset,_count,310,IDL('listreq')+' %'));
             for (var i=0;i<ms.length;i++) mids.push([ms[i].owner_id, ms[i].vid]);
-            if (cur_offset<_count){	cur_offset+=REQ_CNT; setTimeout(scan,SCAN_REQ_DELAY);} else del(deldone);
+            if (cur_offset<_count){	cur_offset+=REQ_CNT; setTimeout(function(){scan();},SCAN_REQ_DELAY);} else del(deldone);
          });
       };
       
@@ -4172,7 +4172,7 @@ vkLastFM={
         if (!paused) return;
         start = new Date();
         if (timerId) window.clearTimeout(timerId);
-        timerId = window.setTimeout(callback, remaining);
+        timerId = window.setTimeout(function(){callback();}, remaining);
         paused=false;
       };
       this.reset = function(){
@@ -5049,7 +5049,7 @@ vk_aalbum={
                else
                   ge('vk_scan_info').innerHTML+='<b>Search failed:</b> '+name+'<br>'; 
                idx++;
-               setTimeout(get_track,(idx%10==0 || !au)?2000:100);
+               setTimeout(function(){get_track();},(idx%10==0 || !au)?2000:100);
                //get_track();
             }
          });
@@ -5137,7 +5137,7 @@ function vkAlbumCollectPlaylist(){
             else
                ge('vk_scan_info').innerHTML+='<b>Search failed:</b> '+name+'<br>'; 
             idx++;
-            setTimeout(get_track,(idx%10==0 || !au)?2000:100);
+            setTimeout(function(){get_track();},(idx%10==0 || !au)?2000:100);
             //get_track();
          }
       });

--- a/source/vk_media.js
+++ b/source/vk_media.js
@@ -521,7 +521,7 @@ var vk_photos = {
       AjGet('/wall'+vk.id+'?offset=100000000',function(t){
          var o=(t.match(/"share":(\{[^}]+\})/)||[])[1];
          if (!o) {alert('hash error'); return;}
-         o=eval('('+o+')');
+         o=JSON.parse(o);
          //alert(o.timehash);
          re(ge('vk_url_upldr_form'));
          var checkURLForm = ce('div', {url:'vk_url_upldr_form', innerHTML: '<iframe name="vk_url_upldr_form_iframe"></iframe>'});
@@ -5661,7 +5661,7 @@ vk_vid_down={
          
          ajax.post('al_video.php', {act: 'load_videos_silent', oid: oid, offset: 0, section:section}, { // please_dont_ddos:2
             onDone: function(_list) {
-               var list = eval('('+_list+')')[section]['list'];
+               var list = JSON.parse(_list)[section]['list'];
                cback(list);
             }
          });
@@ -6041,8 +6041,8 @@ vk_vid_down={
       if (getSet(2)=='y'){
          var vivar=document.getElementsByTagName('body')[0].innerHTML.split('var vars = {')[1];
          if (vivar){
-            vivar='{'+eval('"'+vivar.split('};')[0]+'"')+'}';
-            vkVidVars=eval('('+vivar+')');
+            vivar='{'+ev41('"'+vivar.split('};')[0]+'"')+'}';
+            vkVidVars=JSON.parse(vivar);
             setTimeout(vk_vid_down.vkVidLinks,300);
          } else {
             vkVidVars=null;
@@ -6232,7 +6232,7 @@ vk_vid_down={
          var r = t.match(/clip\d+_\d+\s*=\s*(\{[^;]+\});/);
          //alert(t);
          if (!r) return;
-         var params = eval('(' + r[1] + ')');
+         var params = JSON.parse(r[1]);
          
          var config = params.config;
          var links = [];

--- a/source/vk_media.js
+++ b/source/vk_media.js
@@ -125,7 +125,7 @@ function vkPVAfterShow(){
 		window.PVShowFullHeight=!window.PVShowFullHeight;
       Photoview.doShow();
 	};
-	if (ge('pv_summary')) ge('pv_summary').setAttribute('onclick','vkPVChangeView()');
+	if (ge('pv_summary')) ge('pv_summary').setAttribu7e('onclick','vkPVChangeView()');
 }
 /*
 var orig_cur_chooseMedia=cur.chooseMedia;
@@ -963,12 +963,12 @@ var vk_photos = {
          if (bef && mid){
             bef=bef.getElementsByTagName('a')[0];
             var a=document.createElement('a');
-            a.setAttribute("onfocus","this.blur()");
+            a.setAttribu7e("onfocus","this.blur()");
             a.setAttribute("class"," add_media_item");
             a.setAttribute("id","vk_wall_post_type1");
             a.setAttribute("style","background-image: url(/images/icons/attach_icons.gif); background-position: 3px 3px");
             a.setAttribute("href","#");
-            a.setAttribute("onclick","vk_photos.pz_box("+mid+");return false;");
+            a.setAttribu7e("onclick","vk_photos.pz_box("+mid+");return false;");
             val(a, IDL('PhotoShredder'));
             bef.parentNode.insertBefore(a,bef.nextSibling);
          }
@@ -1647,14 +1647,15 @@ function vkWallAlbumLink(){
    if (!ge('page_wall_header') || ge('vk_wall_album_link')) return;
    if (isVisible('page_wall_switch') || isVisible('page_wall_suggest'))  ge('page_wall_header').appendChild(vkCe('span',{"class":'fl_r right_link divide'},'|'));
    var href=ge('page_wall_header').getAttribute('href');
-   ge('page_wall_header').appendChild(vkCe('a',{
-               "class":'fl_r right_link', 
-               id:'vk_wall_album_link',
-               href:'/album'+cur.oid+'_00?rev=1',
-               onclick:"cancelEvent(event); return nav.go(this, event);",
-               onmouseover:"this.parentNode.href='/album"+cur.oid+"_00?rev=1'",
-               onmouseout:"this.parentNode.href='"+href+"';"
-            },IDL('photo',1)))
+   var vk_wall_album_link = vkCe('a',{
+        "class":'fl_r right_link',
+        id:'vk_wall_album_link',
+        href:'/album'+cur.oid+'_00?rev=1'
+   },IDL('photo',1));
+   vk_wall_album_link.setAttribu7e('onclick',"cancelEvent(event); return nav.go(this, event);");
+   vk_wall_album_link.setAttribu7e('onmouseover',"this.parentNode.href='/album"+cur.oid+"_00?rev=1'");
+   vk_wall_album_link.setAttribu7e('onmouseout',"this.parentNode.href='"+href+"';");
+   ge('page_wall_header').appendChild(vk_wall_album_link);
 }
 
 
@@ -3303,7 +3304,7 @@ vk_audio={
             }
             var btn=geByClass('down_btn',anode)[0] || geByClass('play_new',anode)[0];
             if (!btn) continue;
-            btn.setAttribute('onmouseover',"vk_audio.get_size('"+id+"',this);");
+            btn.setAttribu7e('onmouseover',"vk_audio.get_size('"+id+"',this);");
          }
      }
    },
@@ -3672,7 +3673,9 @@ vk_audio={
 function vkAudioRefreshFriends(){
    var p=ge('audio_more_friends');
    if (!p || ge('vk_audio_fr_refresh')) return;
-   p.parentNode.insertBefore(vkCe('a',{id:'vk_audio_fr_refresh', onclick:"cur.shownFriends=[]; Audio.showMoreFriends(); return false;"},'&#8635;'),p);   
+   var vk_audio_fr_refresh = vkCe('a',{id:'vk_audio_fr_refresh'},'&#8635;');
+   vk_audio_fr_refresh.onclick = function(){ cur.shownFriends=[]; Audio.showMoreFriends(); return false; };
+   p.parentNode.insertBefore(vk_audio_fr_refresh,p);
 }
 function vkAudioEditPage(){
 	vkCleanAudioLink();
@@ -3852,9 +3855,10 @@ function vkAudioDelDup(add_button,btn){
 			if (ge('vk_deldup_btn') || !p) return;
 			var cont=vkCe('div',{"class":'vk_deldup_btn_wrap'});
          p.appendChild(cont);
-         cont.appendChild(vkCe('div',{"class":'no_select filter_open',
-									  "onclick":"searcher.toggleFilter(this, 'vk_del_dup');",
-									  "onselectstart":"return false"},IDL('Duplicates')));
+            var el = vkCe('div',{"class":'no_select filter_open'},IDL('Duplicates'));
+            el.setAttribu7e("onclick","searcher.toggleFilter(this, 'vk_del_dup');");
+            el.setAttribu7e("onselectstart","return false");
+            cont.appendChild(el);
 			cont.appendChild(vkCe('div',{id:"vk_del_dup"},'\
 				<div class="audio_search_filter"><div id="vk_deldup_btn"  style="text-align:center; margin-bottom: 5px;">'+vkButton(IDL('DeleteDuplicates'),"vkAudioDelDup(null,this)")+'</div></div>\
 				<div style="padding-top:10px;" id="deldup_by_size"></div>\
@@ -4068,11 +4072,11 @@ function vkAudioBtns(){
          var p=ge('album_filters');
          var btn=vkCe("div",{
                id:"vkcleanaudios_btn",
-               "class":"audio_filter",
-               onmouseover:"if (Audio.listOver) Audio.listOver(this)",
-               onmouseout:"if (Audio.listOut) Audio.listOut(this)",
-               onclick:"vkCleanAudios();"
+               "class":"audio_filter"
             },'<div class="label">'+IDL('DelAll')+'</div>');
+         btn.setAttribu7e('onmouseover',"if (Audio.listOver) Audio.listOver(this)");
+         btn.setAttribu7e('onmouseout',"if (Audio.listOut) Audio.listOut(this)");
+         btn.setAttribu7e('onclick',"vkCleanAudios();");
          p.insertBefore(btn,p.firstChild);
       }	
       
@@ -4081,12 +4085,12 @@ function vkAudioBtns(){
          var btn=vkCe("div",{
                id:"albumNoSort",
                "class":"audio_filter",
-               stopsort:"1",
-               onmouseover:"if (Audio.listOver) Audio.listOver(this)",
-               onmouseout:"if (Audio.listOut) Audio.listOut(this)",
-               onclick:"vkAudioLoadAlbum('NoSort')"
+               stopsort:"1"
             },'<div class="label">'+IDL('NotInAlbums')+'</div>\
                <div class="icon_wrap" id="albumBanned" onclick="vkAudioLoadAlbum(\'Banned\'); return cancelEvent(event)" onmouseover="addClass(this,\'over\'); showTooltip(this, {text: \''+IDL('AudioBanned')+'\', black: 1, shift: [7, 2, 0]})" onmouseout="removeClass(this, \'over\')"><div class="post_dislike_icon dislike_icon_skull" style="margin:8px 6px "></div></div>');
+         btn.setAttribu7e('onmouseover',"if (Audio.listOver) Audio.listOver(this)");
+         btn.setAttribu7e('onmouseout',"if (Audio.listOut) Audio.listOut(this)");
+         btn.setAttribu7e('onclick', "vkAudioLoadAlbum('NoSort');");
          p.insertBefore(btn,p.firstChild);
       }
 }
@@ -6382,12 +6386,11 @@ vk_au_down={
          var p=ge('album_filters');
          var btn=vkCe("div",{
                id:"vkmp3links",
-               "class":"audio_filter",
-               onmouseover:"if (Audio.listOver) Audio.listOver(this)",
-               onmouseout:"if (Audio.listOut) Audio.listOut(this)",
-               onclick:"vk_au_down.vkAudioPlayList();"
+               "class":"audio_filter"
             },'<div class="label">'+IDL('Links')+'</div>');
-         
+         btn.setAttribu7e('onmouseover', "if (Audio.listOver) Audio.listOver(this)");
+         btn.setAttribu7e('onmouseout', "if (Audio.listOut) Audio.listOut(this)");
+         btn.setAttribu7e('onclick', "vk_au_down.vkAudioPlayList();");
          p.insertBefore(btn,p.firstChild);
          //p.innerHTML+='<span class="divider">|</span><a onclick="vkAudioPlayList(); return false;" href="#" id="vkmp3links">'+IDL('Links')+'</a>';
          return;

--- a/source/vk_media.js
+++ b/source/vk_media.js
@@ -324,18 +324,18 @@ var vk_photos = {
                var el=ge('vk_exinfo_'+pid);
                if (!el) continue;
                //   onclick="vk_skinman.like(\''+pid+'\'); event.cancelBubble = true;" onmouseout="vk_skinman.like_out(\''+pid+'\')"
-               el.innerHTML='<span class="info_wrap">\
+               val(el, '<span class="info_wrap">\
                                <span class="vk_ph_likes_count" onmouseover="vk_photos.like_over(\''+pid+'\')">\
                                  <i class="vk_like_icon_white'+(p.likes.user_likes?' my_like':'')+'" id="s_like_icon'+pid+'"></i>\
                                  <span id="s_like_count'+pid+'">'+p.likes.count+'</span>\
                                </span>'+
                                '<span class="divide"></span>'+
                                '<span class="vk_ph_comm_count"><div class="vk_comm_icon_white"></div> '+p.comments.count+'</span>'+
-                            '</span>';//vk_photos.parse_info(p);//JSON.stringify(p);
+                            '</span>');//vk_photos.parse_info(p);//JSON.stringify(p);
             }
             for (var key in p)
                if (p[key] && ge('vk_exinfo_'+key)) 
-                  ge('vk_exinfo_'+key).innerHTML='';
+                  val(ge('vk_exinfo_'+key), '');
             
          },
          error:function(){}
@@ -412,13 +412,13 @@ var vk_photos = {
             '<div class="pva_camera fl_r">'+a.size+'</div>'*/
          }
          html+='<br id="photos_choose_clear" class="clear">';
-         ge('photos_choose_rows').innerHTML=html;
+         val(ge('photos_choose_rows'), html);
          //console.log(r)
       };
       dApi.call('photos.getAlbums',params,{ok:on_done,error:on_done});
       
       //*
-      ge('photos_choose_rows').innerHTML=vkBigLdrImg;//albums;
+      val(ge('photos_choose_rows'), vkBigLdrImg);//albums;
       hide('photos_choose_more');
       //*/
       return false;
@@ -426,7 +426,7 @@ var vk_photos = {
    choose_album_item:function(oid,aid){
       var PER_PAGE=20;
       //vkMakePageList(0,100,'#','return page(%%);',PER_PAGE,true)
-      ge('photos_choose_rows').innerHTML=vkBigLdrImg;
+      val(ge('photos_choose_rows'), vkBigLdrImg);
       var params={aid:aid};
       params[oid<0?'gid':'uid']=Math.abs(oid);
      
@@ -500,7 +500,7 @@ var vk_photos = {
          }
          html+=pages_html;
          html+='<br id="photos_choose_clear" class="clear">';
-         ge('photos_choose_rows').innerHTML=html; 
+         val(ge('photos_choose_rows'), html);
          return false;
       };
       vk_photos._choose_album_item_page=function(_offset,rev){
@@ -624,7 +624,7 @@ var vk_photos = {
                   file_types_description: 'Image files (*.jpg, *.jpeg, *.png, *.gif)',
                   file_types: '*.jpg;*.JPG;*.jpeg;*.JPEG;*.png;*.PNG;*.gif;*.GIF',
                   onUploadStart:function(){
-                     ge('vk_upd_photo_progress').innerHTML=vkBigLdrImg;
+                     val(ge('vk_upd_photo_progress'), vkBigLdrImg);
                      //lockButton
                   },
                   onUploadComplete: function(u,res){
@@ -677,7 +677,7 @@ var vk_photos = {
             var posts=data.wall;
             var count=posts.shift();
             var len=posts.length;
-            ge('vk_links_container_progr').innerHTML=vkProgressBar(offset,count,600);
+            val(ge('vk_links_container_progr'), vkProgressBar(offset,count,600));
             for (var j=0; j<len; j++){
                var att=posts[j].attachments;
                if (!att) continue;
@@ -697,7 +697,7 @@ var vk_photos = {
             } else {
                var to_file=isChecked('links_to_file');
                vkSetVal('vk_collect_links_to_file',to_file?'1':'0');
-               ge('vk_links_container').innerHTML='<h2>count: '+links.length+'</h2><textarea style="width:560px; height:300px;">'+links.join('\n')+'</textarea>';
+               val(ge('vk_links_container'),'<h2>count: '+links.length+'</h2><textarea style="width:560px; height:300px;">'+links.join('\n')+'</textarea>');
                if (to_file)
                   vkSaveText(links.join('\n'),("wall_photos_"+oid).substr(0,250)+".txt");
             }
@@ -724,7 +724,7 @@ var vk_photos = {
          if (lid>=list.length) {
             var to_file=isChecked('links_to_file');
             vkSetVal('vk_collect_links_to_file',to_file?'1':'0');
-            ge('vk_links_container').innerHTML='<h2>count: '+links.length+'</h2><textarea style="width:590px; height:300px;">'+links.join('\n')+'</textarea>';
+            val(ge('vk_links_container'),'<h2>count: '+links.length+'</h2><textarea style="width:590px; height:300px;">'+links.join('\n')+'</textarea>');
             if (to_file)
                vkSaveText(links.join('\n'),("wall_photos_"+oid).substr(0,250)+".txt");
             return;
@@ -773,7 +773,7 @@ var vk_photos = {
             var posts=data.wall;
             var count=posts.shift();
             var len=posts.length;
-            ge('vk_links_container_progr').innerHTML=vkProgressBar(offset,count,600)+(list.length>1?vkProgressBar(lid,list.length,600):'');
+            val(ge('vk_links_container_progr'), vkProgressBar(offset,count,600)+(list.length>1?vkProgressBar(lid,list.length,600):''));
             for (var j=0; j<len; j++){
                var att=posts[j].attachments;
                if (!att) continue;
@@ -827,28 +827,28 @@ var vk_photos = {
       if (!album) return;
       oid=oid || cur.oid;
       var p=geByClass('module_body',album)[0];
-      p.innerHTML=vkBigLdrImg;
+      val(p, vkBigLdrImg);
       var html='';
       dApi.call('photos.getAlbums',{oid:oid,need_covers:1},function(r){
          var data=r.response;
          if (!data){
-            p.innerHTML=IDL('Error');
+            val(p, IDL('Error'));
             return;
          }
          for (var i=0; i<data.length; i++)
             html+='<a href="/album'+oid+'_'+data[i].aid+'" onclick="return nav.change({z: \'album'+oid+'_'+data[i].aid+'\'}, event)">'+data[i].title+'</a>';
-         p.innerHTML='<div class="vk_albums_list">'+html+'</div>';  
+         val(p, '<div class="vk_albums_list">'+html+'</div>');
       });
    },
     albums_links: function (oid) {   // Реализация функции получения ссылок на все фотографии с группировкой по альбомам. (в виде скрипта)
         var box = vkAlertBox(document.title, '<div id="vk_links_container1"></div><br/><div id="vk_links_container2"></div>');
         var Progress = function (c, f) {    // обновление прогрессбара для альбомов
             if (!f) f = 1;
-            ge('vk_links_container1').innerHTML = vkProgressBar(c, f, 350);
+            val(ge('vk_links_container1'), vkProgressBar(c, f, 350));
         };
         var Progress2 = function (c, f) {    // обновление прогрессбара для фоток внутри альбомов
             if (!f) f = 1;
-            ge('vk_links_container2').innerHTML = vkProgressBar(c, f, 350);
+            val(ge('vk_links_container2'), vkProgressBar(c, f, 350));
         };
         vkApis.albums(oid, function (albums) {
             var wget_strings = [], wget_strings_nix = [],
@@ -969,7 +969,7 @@ var vk_photos = {
             a.setAttribute("style","background-image: url(/images/icons/attach_icons.gif); background-position: 3px 3px");
             a.setAttribute("href","#");
             a.setAttribute("onclick","vk_photos.pz_box("+mid+");return false;");
-            a.innerHTML=IDL('PhotoShredder');
+            val(a, IDL('PhotoShredder'));
             bef.parentNode.insertBefore(a,bef.nextSibling);
          }
       };
@@ -983,10 +983,10 @@ var vk_photos = {
 
 function vkPVPhotoMover(show_selector){
    if (!show_selector && cur.pvCurPhoto && (cur.pvCurPhoto.actions || {}).edit && ge('pv_album_name') && !/vkPVPhotoMover/.test(ge('pv_album_name').innerHTML) && trim(ge('pv_album_name').innerHTML)!="" ){
-      ge('pv_album_name').innerHTML= '<div id="vk_ph_album_info">'+
+      val(ge('pv_album_name'), '<div id="vk_ph_album_info">'+
                                     ge('pv_album_name').innerHTML+
                                     '<div class="fl_r vk_edit_ico" onclick="return vkPVPhotoMover(true);"> </div>'+
-                                 '</div><div id="vk_ph_album_selector"></div>';
+                                 '</div><div id="vk_ph_album_selector"></div>');
       //appendChild(vkCe('div',{'class':'fl_r', id:'vk_ph_move', onclick:"return vkPVPhotoMover(true);"},'edit'));
       return;
    }
@@ -1002,7 +1002,7 @@ function vkPVPhotoMover(show_selector){
    
    var params={};
    params[oid<0?'gid':'uid']=Math.abs(oid);
-   ge('vk_ph_album_selector').innerHTML=vkLdrImg;
+   val(ge('vk_ph_album_selector'), vkLdrImg);
    var btn=vkCe('div',{'class':'button_gray button_wide',id:'vkmakecover'},'<button>'+IDL('MakeCover')+'</button>');
    
    var sel=function(){
@@ -1025,7 +1025,7 @@ function vkPVPhotoMover(show_selector){
              var to_aid=cur.vk_pvMoveToAlbum.val();
              var to_info=cur.vk_pvMoveToAlbum.val_full();
              show('vk_ph_album_info');
-             ge('vk_ph_album_info').innerHTML=vkLdrImg;
+             val(ge('vk_ph_album_info'), vkLdrImg);
              dApi.call('photos.move',{pid:pid,target_aid:to_aid,oid:oid},function(){
                hide('vk_ph_album_info');
                
@@ -1035,7 +1035,7 @@ function vkPVPhotoMover(show_selector){
                var album='<a href="album'+oid+'_'+to_aid+'" onclick="return nav.go(this, event)">'+to_info[1]+'</a>';
                if (album) ph.album = album;
                   ph.moved = (to_aid != def_aid);
-               ge('pv_album_name').innerHTML=album;
+               val(ge('pv_album_name'), album);
 			   
 			   removeClass('pv_narrow','vkPVPhotoMoverOpen');
 			   
@@ -1088,7 +1088,7 @@ function vkPVSaveAndMover(){
    var oid=vk.id;
    var aid=vkGetVal('vk_pru_album') || 0;//0;		
 
-   ge('vk_ph_save_move').innerHTML='<div id="vk_save_selector_label">'+IDL('SelectAlbum')+'</div><div id="vk_ph_save_move_ok"></div><div id="vk_save_selector">'+vkLdrImg+'</div>';
+   val(ge('vk_ph_save_move'), '<div id="vk_save_selector_label">'+IDL('SelectAlbum')+'</div><div id="vk_ph_save_move_ok"></div><div id="vk_save_selector">'+vkLdrImg+'</div>');
    
    var sel=function(){
       stManager.add(['ui_controls.js', 'ui_controls.css'],function(){
@@ -1100,7 +1100,7 @@ function vkPVSaveAndMover(){
                var to_aid=cur.vk_pvMoveToAlbum.val();
                var to_info=cur.vk_pvMoveToAlbum.val_full();
 
-               ge('vk_save_selector_label').innerHTML=vkLdrImg;
+               val(ge('vk_save_selector_label'), vkLdrImg);
 
                var listId = cur.pvListId, index = cur.pvIndex, ph = cur.pvData[listId][index];
                var needmove=function(t){
@@ -1109,8 +1109,8 @@ function vkPVSaveAndMover(){
                      var ph=r.response.pop();
                      dApi.call('photos.move',{pid:ph.pid,target_aid:to_aid,oid:oid},function(){
                         vkSetVal('vk_pru_album',to_aid);
-                        //ge('vk_save_selector_label').innerHTML=IDL('Add');
-                        ge('vk_ph_save_move').innerHTML='';//'ok - album'+oid+'_'+to_aid;
+                        //val(ge('vk_save_selector_label'), IDL('Add'));
+                        val(ge('vk_ph_save_move'), '');//'ok - album'+oid+'_'+to_aid;
                         showDoneBox(t);
                      })                 
                   })
@@ -1129,7 +1129,7 @@ function vkPVSaveAndMover(){
            }
          });
          ge('vk_ph_save_move_ok').className="button_gray fl_r";
-         ge('vk_ph_save_move_ok').innerHTML='<button style="padding:3px 4px">OK</button>';
+         val(ge('vk_ph_save_move_ok'), '<button style="padding:3px 4px">OK</button>');
          ge('vk_ph_save_move_ok').onclick=on_change;         
       });
    };
@@ -1285,11 +1285,11 @@ vk_ph_comms = { // Устарело. Оставить можно только е
       cur.module = 'photos_comments';
       cur.oid=oid;
       cur.offset = 0;
-      (ge('photos_albums') || geByClass('photos_albums_page')[0]).innerHTML='<div id="photos_container" class="clear_fix"></div>\
+      val((ge('photos_albums') || geByClass('photos_albums_page')[0]),'<div id="photos_container" class="clear_fix"></div>\
          <a id="photos_load_more" onclick="vk_ph_comms.load()" style="">\
            <span style="display: inline;">'+IDL('ShowMore')+'</span>\
            <div id="photos_more_progress" class="progress" style="display: none;"></div>\
-         </a>';
+         </a>');
       vk_ph_comms.moreLink=ge('photos_load_more');
       vk_ph_comms.progress=ge('photos_more_progress');
       vk_ph_comms.cont=ge('photos_container');
@@ -1490,14 +1490,14 @@ function vkGetLinksToPhotos(oid,aid){
 		var arr=MakeLinksList(r);
       
       var html=arr[0].join('<br>');
-      div.innerHTML=html+(box?'':
+      val(div, html+(box?'':
 				'<div class="vk_hide_links" style="text-align:center; padding:20px;">\
 					<a href="#" onclick="re(\'vk_links_container\'); return false;">'+IDL('Hide')+'</a>\
-				</div>');
+				</div>'));
       vkSaveText(arr[1],"photos_"+vkCleanFileName((oid||'')+'_'+(aid||'')).substr(0,250)+".txt");
 	},function(c,f){
 		if (!f) f=1;
-		ge('vk_links_container').innerHTML=vkProgressBar(c,f,600);
+		val(ge('vk_links_container'), vkProgressBar(c,f,600));
 		//document.title=c+"/"+f
 	});
 }
@@ -1563,12 +1563,12 @@ function vkGetZipWithPhotos(oid, aid) {
         else {      // При завершении скачивания сохраняем сгенерированный архивчик
             var content = zip.generate({type: "blob"});
             saveAs(content, "photos_" + vkCleanFileName((oid || '') + '_' + (aid || '')).substr(0, 250) + ".zip");
-            div.innerHTML = ''; // очистить прогрессбар
+            val(div, ''); // очистить прогрессбар
         }
     };
     var Progress = function (c, f) {    // обновление прогрессбара
         if (!f) f = 1;
-        ge('vk_links_container').innerHTML = vkProgressBar(c, f, 600);
+        val(ge('vk_links_container'), vkProgressBar(c, f, 600));
     };
     // Когда все библиотеки подключены
     JsZipConnect(function () {
@@ -1609,7 +1609,7 @@ function vkGetPageWithPhotos(oid,aid){
             };
     },function(c,f){
 		if (!f) f=1;
-		ge('ph_ldr_progress').innerHTML=vkProgressBar(c,f,310);
+		val(ge('ph_ldr_progress'), vkProgressBar(c,f,310));
 	});
 }
 
@@ -1883,7 +1883,7 @@ function vkOldPhotos(del_count, ignore_pid){
   };
   //AjGet('photos.php?act=a_album&oid='+oid+'&aid='+aid,function(r,t){
   var count=parseInt(del_count);
-  ge('photos_container').innerHTML=vkBigLdrImg;
+  val(ge('photos_container'), vkBigLdrImg);
   vkDisableAlbumScroll();
   vkAdmGetPhotosWithUsers(oid,aid,function(r){
 	var list=r.response[0];
@@ -1906,11 +1906,11 @@ function vkOldPhotos(del_count, ignore_pid){
                 (( (i+1) % 4 == 0)?'</tr><tr>':'');
         photos_id[photos_id.length]=pid;
       }
-      ge("photos_container").innerHTML=vkSubmDelPhotosBox(count,photos_id.join(','))+
+      val(ge("photos_container"), vkSubmDelPhotosBox(count,photos_id.join(','))+
                                     '<h4>'+IDL('paChkOldPhotos')+'</h4>'+
                                     '<div id="album"><table border="0" cellspacing="0"><tbody><tr>'+
                                     html+'</tr></tbody></table></div>'+
-                                    '<br><br><h4>'+IDL('paIDCheckedPhotos')+'</h4><br>'+photos_id.join(', ');
+                                    '<br><br><h4>'+IDL('paIDCheckedPhotos')+'</h4><br>'+photos_id.join(', '));
     } else {
       alert(IDL('paNullCount'));
     }
@@ -1930,7 +1930,7 @@ return '<div id="DelPhotosDialog'+uid+'" style="padding:20px">'+
 
 function vkRunDelPhotosList(list,uid){
   var plist=list.split(',');
-  ge("DelPhotosDialog"+uid).innerHTML="<h4>"+IDL('paDelStarted')+"</h4>";
+  val(ge("DelPhotosDialog"+uid), "<h4>"+IDL('paDelStarted')+"</h4>");
   vkDeletePhotosList(plist,0,uid);
 }
 function vkDeletePhotosList(list,idx,uid){
@@ -1939,7 +1939,7 @@ function vkDeletePhotosList(list,idx,uid){
       if (t!='FAIL') {
           //setTimeout(function(){fadeOut(ge('ph'+list[idx]))},500);
           fadeTo(ge('ph'+list[idx]), 100, 0.1, function(){
-              ge('ph'+list[idx]).innerHTML=t;
+              val(ge('ph'+list[idx]), t);
               fadeTo(ge('ph'+list[idx]), 500, 1, function(){
                   setTimeout(function(){fadeOut(ge('ph'+list[idx]))},500);
               });
@@ -1947,11 +1947,11 @@ function vkDeletePhotosList(list,idx,uid){
       } else {
         ge('ph'+list[idx]).setAttribute("style","border:2px solid #A00;");
       }
-	  ge("DelPhotosDialog"+uid).innerHTML=vkProgressBar(idx+1,list.length,550,IDL('paDelProc')+' '+(idx+1)+"/"+list.length);
-      //ge("DelPhotosDialog"+uid).innerHTML="<h4>"+IDL('paDelProc')+(idx+1)+"/"+list.length+"</h4>";
+	  val(ge("DelPhotosDialog"+uid), vkProgressBar(idx+1,list.length,550,IDL('paDelProc')+' '+(idx+1)+"/"+list.length));
+      //val(ge("DelPhotosDialog"+uid), "<h4>"+IDL('paDelProc')+(idx+1)+"/"+list.length+"</h4>");
       setTimeout(function(){vkDeletePhotosList(list,idx+1,uid)},500);
     } else { 
-		ge("DelPhotosDialog"+uid).innerHTML="<h4>"+IDL('paDelSuc')+"</h4>";
+		val(ge("DelPhotosDialog"+uid), "<h4>"+IDL('paDelSuc')+"</h4>");
 		//alert(IDL('paDelSuc'));
 	}
   });
@@ -1979,7 +1979,7 @@ function vkDelOnePhoto(pid, callback) {
 }
 
 function vkGetPhotoByUser(u,oid,aid,toel){
-ge('photos_container').innerHTML=vkBigLdrImg;
+val(ge('photos_container'), vkBigLdrImg);
 vkDisableAlbumScroll();
 getGidUid(u,function(userid,groupid){
   userid = userid || groupid;
@@ -1997,7 +1997,7 @@ getGidUid(u,function(userid,groupid){
 	}
     var uids={};
     var uid;
-    ResultElem.innerHTML="<br>";
+    val(ResultElem, "<br>");
     for (var i=0; i<list.length; i++){
       uid=list[i].user_id;//owner_id;
       if (uids[uid]) {
@@ -2082,8 +2082,8 @@ function vkRunAllBanAndDelPhotos(gid){
     for (var i=0;i<ids.length;i++){
         users+=ge('vkusername'+ids[i]).innerHTML+'<br>';
     }
-     ge("photos_container").innerHTML=vkSubmBanPhotosBox(ids.length,idss,0,gid,users)+
-                                   vkSubmDelPhotosBox(list.length,list.join(','))+html;
+     val(ge("photos_container"), vkSubmBanPhotosBox(ids.length,idss,0,gid,users)+
+                                   vkSubmDelPhotosBox(list.length,list.join(','))+html);
   }
 }
 
@@ -2106,7 +2106,7 @@ function vkRunDelCheckedPhotosList(){
        html+='<td>'+photos[i]+'</td>'+(( (i+1) % 4 == 0)?'</tr><tr>':'');
     }
     html+='</table>';
-    ge("photos_container").innerHTML=vkSubmDelPhotosBox(list.length,list.join(','))+html;
+    val(ge("photos_container"), vkSubmDelPhotosBox(list.length,list.join(','))+html);
 }
 
 
@@ -2129,7 +2129,7 @@ function vkRunBanAll(gid){
     for (var i=0;i<ids.length;i++){
         users+=ge('vkusername'+ids[i]).innerHTML+'<br>';
     }
-     ge("photos_container").innerHTML=vkSubmBanPhotosBox(ids.length,idss,0,gid,users);
+     val(ge("photos_container"), vkSubmBanPhotosBox(ids.length,idss,0,gid,users));
      //users+'<div id="banProc"></div>';
     // vkBanUserList(idss,gid,ge("BanDialog0"),users);
   }
@@ -2140,14 +2140,14 @@ function vkBanUserList(users,gid,info_el){
   info_el=ge(info_el);
   /*
   var BanUser=function(id,gid,callback){
-    info_el.innerHTML="<h4>"+IDL('paBanUsers')+": "+(idx+1)+"/"+users.length+"</h4>";
+    val(info_el, "<h4>"+IDL('paBanUsers')+": "+(idx+1)+"/"+users.length+"</h4>");
     AjGet("/groups_ajax.php?act=a_inv_by_link&b=1&page="+id+"&gid="+gid,function(req){
       req=req.responseText;
       req=req.replace('id="invForm"','class="invForm"');
       var hash = req.match(/"hash".value="(.+)"/i)[1];
       req=req.replace(hash,decodehash(hash));
       div = document.createElement('div');
-      div.innerHTML=req;
+      val(div, req);
       var form = geByClass('invForm', div)[0];
       var url="/groups_ajax.php?"+ajx2q(serializeForm(form));  
       AjGet(url,callback);
@@ -2155,11 +2155,11 @@ function vkBanUserList(users,gid,info_el){
   }*/
   var onDone=function(text){
     if (idx<users.length){
-      info_el.innerHTML=vkProgressBar(idx+1,users.length,550,IDL('paBanUsers')+": "+(idx+1)+"/"+users.length)+'<br><br>'+text;
-	  //info_el.innerHTML="<h4>"+IDL('paBanUsers')+": "+(idx+1)+"/"+users.length+"</h4>";
+      val(info_el, vkProgressBar(idx+1,users.length,550,IDL('paBanUsers')+": "+(idx+1)+"/"+users.length)+'<br><br>'+text);
+	  //val(info_el, "<h4>"+IDL('paBanUsers')+": "+(idx+1)+"/"+users.length+"</h4>");
 	  vkBanUserFunc('id'+users[idx],gid,onDone);
     } else {
-		info_el.innerHTML=IDL('Done');
+		val(info_el, IDL('Done'));
 		alert(IDL('Done'));
 	}
     idx++;
@@ -2226,7 +2226,7 @@ function vkAdmGetPhotosWithUsers(oid,aid,callback){
       scan();
 }
 function vkAlbumCheckDublicatUser(){//oid,aid
-  ge('photos_container').innerHTML=vkBigLdrImg;
+  val(ge('photos_container'), vkBigLdrImg);
   vkDisableAlbumScroll();
   var aoid=cur.moreFrom.match(/album(-?\d+)_(\d+)/);
   var aid=aoid[2];
@@ -2243,7 +2243,7 @@ function vkAlbumCheckDublicatUser(){//oid,aid
 	//alert(print_r(list));
     var uids={};
     var uid;
-    ge("photos_container").innerHTML='<br>'+
+    val(ge("photos_container"), '<br>'+
                                   '<a id="delchecked" style="cursor: hand;" onClick="vkRunDelCheckedPhotosList(); return false;">'+IDL('paDelChecked')+'</a>'+
                                   '<span class="divider">|</span>'+
                                   '<a style="cursor: hand;" onClick="vkDoCheck(1,\'vkphcheck\'); return false;">'+IDL('CheckAll')+'</a>'+
@@ -2253,7 +2253,7 @@ function vkAlbumCheckDublicatUser(){//oid,aid
                                   '<a id="banallusers" style="cursor: hand;" onClick="vkRunBanAll('+oid.match(/\d+/)[0]+'); return false;">'+IDL('paBanAll')+'</a>'+
                                   '<span class="divider">|</span>'+
                                   '<a id="bandelallusers" style="cursor: hand;" onClick="vkRunAllBanAndDelPhotos('+oid.match(/\d+/)[0]+'); return false;">'+IDL('paBanAllAndDelPhotos')+'</a>'+
-                                  '<br><br>';
+                                  '<br><br>');
                        
     for (var i=0; i<list.length; i++){
       uid=list[i].user_id;//owner_id//[1].match(/u(\d+)/)[1];
@@ -2488,13 +2488,13 @@ vk_videos = {
                   html+='<a class="album_choose" href="#" onclick="return vk_videos.choose_album_item('+a.owner_id+',\''+a.album_id+'\');"><b class="vk_video_icon"></b>'+a.title+'</a>';
                }
                html+='<br class="clear">';
-                ge('choose_video_rows').innerHTML=html;
+                val(ge('choose_video_rows'), html);
             }
          });
       };
       scan(0);
       //*
-      ge('choose_video_rows').innerHTML=vkBigLdrImg;//albums;
+      val(ge('choose_video_rows'), vkBigLdrImg);//albums;
       hide('video_choose_more');
       //*/
       return false;
@@ -2506,7 +2506,7 @@ vk_videos = {
 
       var page=function(offset){
          
-         ge('choose_video_rows').innerHTML=vkBigLdrImg;
+         val(ge('choose_video_rows'), vkBigLdrImg);
          var params={owner_id:oid, album_id:aid, width:130, count:PER_PAGE, offset:offset};
 
          var items=null;
@@ -2532,7 +2532,7 @@ vk_videos = {
             }
             html+=pages_html;
             html+='<br class="clear">';
-            ge('choose_video_rows').innerHTML=html; 
+            val(ge('choose_video_rows'), html);
          }); 
          return false;
       };
@@ -2559,10 +2559,10 @@ vk_videos = {
       var del=function(callback){	
          if (abort) return;
          var del_count=mids.length;
-         ge('vk_del_msg').innerHTML=vkProgressBar(del_offset,del_count,310,IDL('deleting')+' %');
+         val(ge('vk_del_msg'), vkProgressBar(del_offset,del_count,310,IDL('deleting')+' %'));
          var item_id=mids[del_offset];
          if (!item_id){
-            ge('vk_del_msg').innerHTML=vkProgressBar(1,1,310,' ');
+            val(ge('vk_del_msg'), vkProgressBar(1,1,310,' '));
             del_offset=0;
             callback();
          } else
@@ -2574,7 +2574,7 @@ vk_videos = {
       
       var cur_offset=0;
       var scan=function(){
-         if (cur_offset==0) ge('vk_scan_msg').innerHTML=vkProgressBar(cur_offset,2,310,IDL('listreq')+' %');
+         if (cur_offset==0) val(ge('vk_scan_msg'), vkProgressBar(cur_offset,2,310,IDL('listreq')+' %'));
          
          var params={};
          params['owner_id']=cur.oid;
@@ -2586,7 +2586,7 @@ vk_videos = {
             var ms=r.response;
             if (!ms[0]){ del(deldone);	return;	}
             var _count=ms.shift();
-            ge('vk_scan_msg').innerHTML=vkProgressBar(cur_offset,_count,310,IDL('listreq')+' %');
+            val(ge('vk_scan_msg'), vkProgressBar(cur_offset,_count,310,IDL('listreq')+' %'));
             for (var i=0;i<ms.length;i++) mids.push([ms[i].owner_id, ms[i].vid]);
             if (cur_offset<_count){	cur_offset+=REQ_CNT; setTimeout(scan,SCAN_REQ_DELAY);} else del(deldone);
          });
@@ -2672,7 +2672,7 @@ vk_videos = {
          })
       }
       stManager.add(['video_edit.css','ui_controls.js', 'ui_controls.css','wkview.css'],function(){
-         ge('vk_vid_album_selector').innerHTML=vkLdrImg;
+         val(ge('vk_vid_album_selector'), vkLdrImg);
          /*
          collect_albums(function(list){
                var items=[];
@@ -2722,7 +2722,7 @@ vk_videos = {
          if (filtred_vids.length>0){
             if (vk_DEBUG) console.log(filtred_vids.length);
             //
-            ge('vid_move_progress').innerHTML=vkProgressBar(filtred_vids_count-filtred_vids.length,filtred_vids_count,310,(filtred_vids_count-filtred_vids.length)+'/'+filtred_vids_count);
+            val(ge('vid_move_progress'), vkProgressBar(filtred_vids_count-filtred_vids.length,filtred_vids_count,310,(filtred_vids_count-filtred_vids.length)+'/'+filtred_vids_count));
             var vid = filtred_vids.shift();
             /*
             var part=filtred_vids.splice(0,30);
@@ -2809,13 +2809,13 @@ vk_videos = {
          }
          if (filtred_vids[0])
             first_video=[filtred_vids[0][0],filtred_vids[0][1]];
-         ge('vid_filt_list').innerHTML=lst;
+         val(ge('vid_filt_list'), lst);
          
          ge('vk_run_move_btn').onclick=function(){
             move(function(){
-               ge('vid_filt_list').innerHTML='';
+               val(ge('vid_filt_list'), '');
                hide('vk_move_ctrls');
-               ge('vid_move_progress').innerHTML='';
+               val(ge('vid_move_progress'), '');
                dApi.call('video.restore',{oid:first_video[0],vid:first_video[1]},function(){});
                vkMsg('Done');
                
@@ -2983,7 +2983,7 @@ function vkVidEditAlbumTitle(album_id,add_buttons){ // Вероятно уста
             
             var text=el.innerHTML;
             if (text.indexOf('album_title_'+aid)!=-1) continue;
-            el.innerHTML='<span id="album_title_'+aid+'">'+text+'</span><div class="fl_r vk_edit_ico" onclick="vkVidEditAlbumTitle('+aid+');" onmousedown="cancelEvent(event);"> </div>';
+            val(el, '<span id="album_title_'+aid+'">'+text+'</span><div class="fl_r vk_edit_ico" onclick="vkVidEditAlbumTitle('+aid+');" onmousedown="cancelEvent(event);"> </div>');
          }
          return;
       }
@@ -2992,9 +2992,9 @@ function vkVidEditAlbumTitle(album_id,add_buttons){ // Вероятно уста
       aBox.removeButtons();
       
       var edit_done=function(){  
-            var val=ge('albumedit_'+album_id).value;
+            var _val=ge('albumedit_'+album_id).value;
             var params={
-               title:val,
+               title:_val,
                album_id:album_id
             };
             if (cur.oid<0) 
@@ -3002,7 +3002,7 @@ function vkVidEditAlbumTitle(album_id,add_buttons){ // Вероятно уста
                
             dApi.call('video.editAlbum',params,function(r){
                if (r.response==1)
-                  ge('album_title_'+album_id).innerHTML=val;
+                  val(ge('album_title_'+album_id), _val);
                else
                   alert('Rename error');
             });
@@ -3089,7 +3089,7 @@ var vk_oid_names={};
 function vkVidShowOwnerName(oid,el){
    //el=el.getElementsByTagName('span')[0] || el;
    if (el && !el.hasAttribute('ok')){
-      el.innerHTML=vkLdrMiniImg;
+      val(el, vkLdrMiniImg);
       var code='';
       if (oid>0){
          code='var u=API.users.get({uids:'+oid+'}); return u[0].first_name+" "+u[0].last_name;';
@@ -3097,7 +3097,7 @@ function vkVidShowOwnerName(oid,el){
          code='var g=API.groups.getById({gid:'+Math.abs(oid)+'}); return g[0].name;';
       }
       var view=function(){
-         el.innerHTML=vk_oid_names[""+oid];
+         val(el, vk_oid_names[""+oid]);
          el.setAttribute('ok',true); 
       };
       if (vk_oid_names[""+oid])
@@ -3118,8 +3118,8 @@ function vkAudioPlayer(){
    /*
     && INJ_AUDIOPLAYER_DUR_MOD){
       window.vkAudioDurMod=function(res){   return vkAudioDurSearchBtn(res,audioPlayer.lastSong[5]+' - '+audioPlayer.lastSong[6],audioPlayer.id) }
-      Inj.Replace('audioPlayer.setCurTime','dur.innerHTML = res','dur.innerHTML = vkAudioDurMod(res)');
-      Inj.Replace('audioPlayer.setGraphics','dur.innerHTML = res','dur.innerHTML = vkAudioDurMod(res)');
+      Inj.Replace('audioPlayer.setCurTime','val(dur, res','dur.innerHTML = vkAudioDurMod(res)'));
+      Inj.Replace('audioPlayer.setGraphics','val(dur, res','dur.innerHTML = vkAudioDurMod(res)'));
    }*/
    vk_audio_player.inj();
 }
@@ -3170,7 +3170,7 @@ vk_audio_player={
       }
       if (vk_audio_player.last_vol==-1/*!=cur_vol*/){
          vk_audio_player.last_vol=cur_vol;
-         el.innerHTML='';
+         val(el, '');
          
          var set=function(volume){
             //console.log(volume);
@@ -3295,7 +3295,7 @@ vk_audio={
               var name=el.parentNode.getElementsByTagName('b')[0].innerText+' - '+(span_title || ge('title'+id) || spans[1] || spans[0]).innerText;
               name=vkCleanFileName(name);
               if (smartlink) {url+=(url.indexOf('?')>0?'':'?')+vkDownloadPostfix()+'&/'+vkEncodeFileName(name)+'.mp3';}//normal name
-              //if (SearchLink && el){el.innerHTML=vkAudioDurSearchBtn(el.innerText,name,id);/* "<a href='/search?c[section]=audio&c[q]="+name+"'>"+el.innerText+"</a>";*/}
+              //if (SearchLink && el){val(el, vkAudioDurSearchBtn(el.innerText,name,id));/* "<a href='/search?c[section]=audio&c[q]="+name+"'>"+el.innerText+"</a>";*/}
             if (download){
                divs[i].setAttribute('style','width:17px;');
                divs[i].setAttribute('vk_ok','1');
@@ -3326,11 +3326,11 @@ vk_audio={
       var el=ge("vk_asize"+id);
       if (el && !el.hasAttribute('getsize_ok')){
          el.setAttribute('getsize_ok',true);
-         el.innerHTML=vkLdrMiniImg;
+         val(el, vkLdrMiniImg);
          var dur=el.getAttribute('dur');
          var reset=setTimeout(function(){
             el.removeAttribute('getsize_ok');
-            el.innerHTML='';
+            val(el, '');
             vk_audio.thread_count--;
             rb = false;
          },WAIT_TIME);
@@ -3346,7 +3346,7 @@ vk_audio={
                var info = [];
                if (AUDIO_INFO_SHOW_FILESIZE) info.push(vkFileSize(l,1));
                if (AUDIO_INFO_SHOW_BITRATE)  info.push(kbps+'Kbps');
-               el.innerHTML=info.join(' | ');
+               val(el, info.join(' | '));
                el.setAttribute('getsize_ok',true);
                
                var au_el = ge('audio'+id);
@@ -3355,7 +3355,7 @@ vk_audio={
                   au_el.setAttribute('filesize',l);
                }
             } else {
-               el.innerHTML='o_O';
+               val(el, 'o_O');
             }
             /* костыли с педалями и тормозами */
             if (window.sorter && sorter.update && ge('audio'+id) && (ge('audio'+id).parentNode || {}).sorter)
@@ -3533,7 +3533,7 @@ vk_audio={
                   html+='<a class="album_choose" href="#" onclick="return vk_audio.choose_album_item('+a.owner_id+',\''+a.album_id+'\');"><b class="vk_audio_icon"></b> '+a.title+'</a>';
                }
                html+='<br class="clear">';
-                ge('choose_audio_rows').innerHTML=html;
+                val(ge('choose_audio_rows'), html);
             }
             //// done?
             //console.log(r)
@@ -3541,7 +3541,7 @@ vk_audio={
       };
       scan(0);
       //*
-      ge('choose_audio_rows').innerHTML=vkBigLdrImg;//albums;
+      val(ge('choose_audio_rows'), vkBigLdrImg);//albums;
       hide('audio_choose_more');
       //*/
       return false;
@@ -3549,7 +3549,7 @@ vk_audio={
    choose_album_item:function(oid,aid){
       var PER_PAGE=20;
       //vkMakePageList(0,100,'#','return page(%%);',PER_PAGE,true)
-      ge('choose_audio_rows').innerHTML=vkBigLdrImg;
+      val(ge('choose_audio_rows'), vkBigLdrImg);
       var params={album_id:aid};// count, offset
       params[oid<0?'gid':'uid']=Math.abs(oid);
      
@@ -3582,7 +3582,7 @@ vk_audio={
          }
          html+=pages_html;
          html+='<br class="clear">';
-         ge('choose_audio_rows').innerHTML=html; 
+         val(ge('choose_audio_rows'), html);
          return false;
       };
       vk_audio._choose_album_item_page=function(_offset,rev){
@@ -3699,10 +3699,10 @@ function vkCleanAudios(){
 	var del=function(callback){	
 		if (abort) return;
 		var del_count=mids.length;
-		ge('vk_del_msg').innerHTML=vkProgressBar(del_offset,del_count,310,IDL('deleting')+' %');
+		val(ge('vk_del_msg'), vkProgressBar(del_offset,del_count,310,IDL('deleting')+' %'));
 		var aid=mids[del_offset];
 		if (!aid){
-			ge('vk_del_msg').innerHTML=vkProgressBar(1,1,310,' ');
+			val(ge('vk_del_msg'), vkProgressBar(1,1,310,' '));
 			del_offset=0;
 			callback();
 		} else
@@ -3714,8 +3714,8 @@ function vkCleanAudios(){
 	
 	var scan=function(){
 		mids=[];
-		ge('vk_del_msg').innerHTML=vkProgressBar(1,1,310,' ');
-		ge('vk_scan_msg').innerHTML=vkProgressBar(0,2,310,IDL('listreq')+' %');
+		val(ge('vk_del_msg'), vkProgressBar(1,1,310,' '));
+		val(ge('vk_scan_msg'), vkProgressBar(0,2,310,IDL('listreq')+' %'));
 		var params={};
 		params[cur.oid>0?"uid":"gid"]=Math.abs(cur.oid);
 		dApi.call('audio.get',params,function(r){
@@ -3725,7 +3725,7 @@ function vkCleanAudios(){
 				deldone();
 				return;
 			}
-			ge('vk_scan_msg').innerHTML=vkProgressBar(2,2,310,IDL('listreq')+' %');
+			val(ge('vk_scan_msg'), vkProgressBar(2,2,310,IDL('listreq')+' %'));
 			for (var i=0;i<ms.length;i++) mids.push(ms[i].aid);
 			vklog(mids);
 			del(deldone);	
@@ -3755,7 +3755,7 @@ vkAudioEd = {
         if (!cur.deletedAudios) cur.deletedAudios = [];
         cur.deletedAudios[id] = ge('audio'+aid).innerHTML;
         text=text.replace(/AudioEdit.restoreAudio\(\d+\)/,'vkAudioEd.Restore('+id+',\''+aid+'\')');
-        el.innerHTML = text;
+        val(el, text);
         h=30;
         setStyle(geByClass1('dld', el), {height: h+'px'});
         //el.style.cursor = 'auto';
@@ -3781,7 +3781,7 @@ vkAudioEd = {
     ajax.post(Audio.address, {act: 'restore_audio', oid: cur.oid, aid: id, hash: cur.hashes.restore_hash}, {
       onDone: function() {
         cur.restoring = false;
-        el.innerHTML = cur.deletedAudios[id];
+        val(el, cur.deletedAudios[id]);
         //el.style.cursor = 'move';
         //el.removeAttribute('nosorthandle');
         cur.audiosIndex.add(cur.audios[id]);
@@ -3887,7 +3887,7 @@ function vkAudioDelDup(add_button,btn){
 				dcount++;
 			} else adata[check_id]=true;
 		}
-		ge('vk_deldup_text').innerHTML=IDL('Deleted')+': '+dcount;
+		val(ge('vk_deldup_text'), IDL('Deleted')+': '+dcount);
 		unlockButton(btn);
 	};
 	var check_pro=function(){
@@ -3933,12 +3933,12 @@ function vkAudioDelDup(add_button,btn){
 					rdata[check_id]=[info.size,info.node,info.aid];
 				}
 			}
-			ge('vk_deldup_text').innerHTML=IDL('Deleted')+': '+dcount;
+			val(ge('vk_deldup_text'), IDL('Deleted')+': '+dcount);
 			unlockButton(btn);
 		};
 		var get_sizes=function(){
 			if (urls[idx]){
-				ge('vk_deldup_text').innerHTML=vkProgressBar(idx,urls.length,150,idx+'/'+urls.length);
+				val(ge('vk_deldup_text'), vkProgressBar(idx,urls.length,150,idx+'/'+urls.length));
 				XFR.post(urls[idx][0],{},function(h,l){
 					adata[urls[idx][1]].size=l;
 					idx++;
@@ -4004,10 +4004,10 @@ function vkAddAudio(aid,oid,callback){
 }
 function vkAddAudioT(oid,aid,el){
 	var p=el;//.parentNode;
-	p.innerHTML=vkLdrImg;
+	val(p, vkLdrImg);
 	vkAddAudio(aid,oid,function(r){  
-      if (r) p.innerHTML=IDL('AddMyAudio')+' - '+IDL('Done');
-		else p.innerHTML=IDL('AddMyAudio')+' - '+IDL('Error');
+      if (r) val(p, IDL('AddMyAudio')+' - '+IDL('Done'));
+		else val(p, IDL('AddMyAudio')+' - '+IDL('Error'));
 	});
 }
 function vkAudioWikiCode(aid,oid,id){vkAlertBox('Wiki-code:','<center><input type="text" value="[[audio'+aid+']]" readonly onClick="this.focus();this.select();" size="25"/><br><br>\
@@ -4034,7 +4034,7 @@ function vkShowAddAudioTip(el,id){
 		var links = '<div class="vk_tt_links_list">'+html+'</div>';
       
       if (el.tt && el.tt.container){
-         geByClass('vk_tt_links_list',el.tt.container)[0].innerHTML=html;
+         val(geByClass('vk_tt_links_list',el.tt.container)[0], html);
       }
       showTooltip(el, {
 		  hasover:true,
@@ -4672,7 +4672,7 @@ vkLastFM={
                         var t=geByClass('lastfm_timer',tt.container)[0];  
                         upd=setInterval(function(){
                            if (t)
-                              t.innerHTML=time();
+                              val(t, time());
                            else
                               clearInterval(upd);
                            
@@ -4877,7 +4877,7 @@ function vkViewAlbumInfo(artist,track){
       return;
    }
    if (hasClass('vk_album_info','fixed_album')) return;
-   ge('vk_album_info').innerHTML='';
+   val(ge('vk_album_info'), '');
    vk_alb_last_track=artist+'-'+track;
    vk_current_album_info=null;
    vkGetAlbumInfo(artist,track,function(data,tracks){
@@ -4922,7 +4922,7 @@ function vkViewAlbumInfo(artist,track){
                                     .replace(/%IMG2%/g,data.image[2]['#text'] || '/images/question_c.gif')
                                     .replace(/%TRACKS%/g,html || (data.bio.summary?'<div class="bio">'+data.bio.summary+'</div>':''));      
       }
-      ge('vk_album_info').innerHTML=html;
+      val(ge('vk_album_info'), html);
       
    });
 }
@@ -4965,7 +4965,7 @@ function vkGetSongInfoFromNode(node) {
 vk_aalbum={
    s_cache:{},
    s_toggle:function(idx){
-      ge('vk_audios_search'+idx).innerHTML=trim(ge('vk_audios_search'+idx).innerHTML)!=''?'':vk_aalbum.s_cache['au'+idx];
+      val(ge('vk_audios_search'+idx), trim(ge('vk_audios_search'+idx).innerHTML)!=''?'':vk_aalbum.s_cache['au'+idx]);
    },
    search_tracks:function(list){
       if (!list || !list.length) return;
@@ -4995,9 +4995,9 @@ vk_aalbum={
             cur.audiosList[cur.curList] = [];
             
             removeClass(cur.searchCont, 'loading');
-            cur.aContent.innerHTML = '';
-            cur.sContent.innerHTML = '';
-            if (window.vk_au_down) cur.sContent.innerHTML = '<a href="#" id="vk_links_to_audio_on_page" onclick="return vk_audio.links_to_audio_on_page();">'+IDL('Links')+'</a>';
+            val(cur.aContent, '');
+            val(cur.sContent, '');
+            if (window.vk_au_down) val(cur.sContent, '<a href="#" id="vk_links_to_audio_on_page" onclick="return vk_audio.links_to_audio_on_page();">'+IDL('Links')+'</a>');
             cur.sContent.innerHTML += result.innerHTML;
             show(cur.sContent);
             hide(cur.sShowMore);
@@ -5006,7 +5006,7 @@ vk_aalbum={
             return;
          }
             
-         ge('vk_scan_msg').innerHTML=vkProgressBar(idx,list.length,310, '['+idx+'/'+list.length+'] %');  
+         val(ge('vk_scan_msg'), vkProgressBar(idx,list.length,310, '['+idx+'/'+list.length+'] %'));
 
          //progressbar
          
@@ -5055,7 +5055,7 @@ vk_aalbum={
          });
       };
       addClass(cur.searchCont, 'loading');
-      //cur.aContent.innerHTML = '';
+      //val(cur.aContent, '');
       
       box=new MessageBox({title: IDL('Searching...'),closeButton:true,width:"350px", onHide:function(){abort=true; get_track();} });
       box.removeButtons();
@@ -5094,9 +5094,9 @@ function vkAlbumCollectPlaylist(){
          cur.audiosList[cur.curList] = [];
          
          removeClass(cur.searchCont, 'loading');
-         cur.aContent.innerHTML = '';
-         cur.sContent.innerHTML = '';
-         if (window.vk_au_down) cur.sContent.innerHTML = '<a href="#" id="vk_links_to_audio_on_page" onclick="return vk_audio.links_to_audio_on_page();">'+IDL('Links')+'</a>';
+         val(cur.aContent, '');
+         val(cur.sContent, '');
+         if (window.vk_au_down) val(cur.sContent, '<a href="#" id="vk_links_to_audio_on_page" onclick="return vk_audio.links_to_audio_on_page();">'+IDL('Links')+'</a>');
          cur.sContent.innerHTML += result.innerHTML;
          show(cur.sContent);
          hide(cur.sShowMore);
@@ -5105,7 +5105,7 @@ function vkAlbumCollectPlaylist(){
          return;
       }
          
-      ge('vk_scan_msg').innerHTML=vkProgressBar(idx,vk_current_album_info.tracks.length,310, '['+idx+'/'+vk_current_album_info.tracks.length+'] %');  
+      val(ge('vk_scan_msg'), vkProgressBar(idx,vk_current_album_info.tracks.length,310, '['+idx+'/'+vk_current_album_info.tracks.length+'] %'));
 
       //progressbar
       var track_artist = (vk_current_album_info.artist || vk_current_album_info.name);
@@ -5143,7 +5143,7 @@ function vkAlbumCollectPlaylist(){
       });
    };
    addClass(cur.searchCont, 'loading');
-   //cur.aContent.innerHTML = '';
+   //val(cur.aContent, '');
    
    box=new MessageBox({title: IDL('Searching...'),closeButton:true,width:"350px", onHide:function(){abort=true; get_track();}});
    box.removeButtons();
@@ -5305,7 +5305,7 @@ vk_apps = {
       show(wraps[i]);
       show(results[i]);
       
-      contents[i].innerHTML='';
+      val(contents[i], '');
       hide(more_buttons[i]);
       var html = [];
       for (var k in apps) {
@@ -5412,7 +5412,7 @@ vk_vid_down={
          //alert(html);
          for (var i=0;i<r.length;i++)
             html+='<a href="'+r[i][0]+'" title="'+r[i][1]+'"  class="clear_fix">'+IDL("download")+' ['+r[i][1]+']</a>';
-         ge('vkyoutubelinks').innerHTML='<a id="vkyoutubelinks_show" href="javascript: toggle(\'vkyoutubelinks_list\');">'+IDL('download')+'</a><span id="vkyoutubelinks_list" style="display:none;">'+html+'</span>';    });
+         val(ge('vkyoutubelinks'), '<a id="vkyoutubelinks_show" href="javascript: toggle(\'vkyoutubelinks_list\');">'+IDL('download')+'</a><span id="vkyoutubelinks_list" style="display:none;">'+html+'</span>');    });
       return '<span id="vkyoutubelinks"></span>';
    },
    vkVideoGetLinksBtn: function(){
@@ -5452,23 +5452,23 @@ vk_vid_down={
       var run=function(quality){
          q = quality!=null?quality:3;
          box.setOptions({width:"640px"});
-         ge('vk_links_container').innerHTML=vkBigLdrImg;
+         val(ge('vk_links_container'), vkBigLdrImg);
          vk_vid_down.videos(oid,aid,q,function(r){
             show_links(r);
          },function(c,f){
             if (!f) f=1;
-            ge('vk_links_container').innerHTML=vkProgressBar(c,f,600);
+            val(ge('vk_links_container'), vkProgressBar(c,f,600));
          });
          return false;
       };
       
-      ge('vk_links_container').innerHTML='\
+      val(ge('vk_links_container'), '\
       <a class="vk_down_icon" href="#"  id="vk_glinks_max240p">240p<small class="divide">max</small></a>\
       <a class="vk_down_icon" href="#"  id="vk_glinks_max360p">360p<small class="divide">max</small></a>\
       <a class="vk_down_icon" href="#"  id="vk_glinks_max480p">480p<small class="divide">max</small></a>\
       <a class="vk_down_icon" href="#"  id="vk_glinks_max720p">720p<small class="divide">max</small></a>\
       <a class="vk_down_icon" href="#"  id="vk_glinks_max1080p">1080p<small class="divide">max</small></a>\
-      ';
+      ');
       ge('vk_glinks_max240p').onclick=run.pbind(0);
       ge('vk_glinks_max360p').onclick=run.pbind(1);
       ge('vk_glinks_max480p').onclick=run.pbind(2);
@@ -5878,8 +5878,8 @@ vk_vid_down={
            el.insertBefore(c,el.firstChild);
            if (el.innerHTML.indexOf('get_description')==-1){
                var c=geByClass('video_raw_info_name',el)[0];
-               if (c) c.innerHTML='<span class="vk_txt_icon" onclick="cancelEvent(event); vk_videos.get_description('+vid[1]+','+vid[2]+',this);"></span>'+
-                                   c.innerHTML
+               if (c) val(c, '<span class="vk_txt_icon" onclick="cancelEvent(event); vk_videos.get_description('+vid[1]+','+vid[2]+',this);"></span>'+
+                                   c.innerHTML);
            }
            // <div class="vk_vid_acts_panel">okoko</div>
          }
@@ -5924,7 +5924,7 @@ vk_vid_down={
        var smartlink=true;//(getSet(1) == 'y')?true:false;
        var fmt=['240p','360p','480p','720p','1080p'];
        el=ge(el);
-       el.innerHTML=vkLdrImg;
+       val(el, vkLdrImg);
        AjGet('/video.php?act=a_flash_vars&vid='+oid+'_'+vid,function(t){
          //console.log(t);
          // if (t=='NO_ACCESS')
@@ -5934,7 +5934,7 @@ vk_vid_down={
                   if (!r) return;
                   for (var i=0;i<r.length;i++)
                      html+='<a class="vk_down_icon" href="'+r[i][0]+'" title="'+r[i][2]+'" onmouse_over="vk_vid_down.vkGetVideoSize(this);">'+r[i][1]+'<small class="divide" url="'+r[i][0]+'"></small></a>';
-                  el.innerHTML=html; 
+                  val(el, html);
                   addClass(el,'vk_vide_wide_lnks');
                   
                });
@@ -5947,7 +5947,7 @@ vk_vid_down={
                //alert(html);
                for (var i=0;i<r.length;i++)
                   html+='<a href="'+r[i][0]+'" title="'+r[i][2]+'"  class="vk_down_icon">'+r[i][1]+'<small class="divide">'+r[i][2]+'</small></a>';
-               el.innerHTML=html;
+               val(el, html);
             });  
          };
          var get_ivi=function(ivi_id){
@@ -5961,7 +5961,7 @@ vk_vid_down={
                //alert(html);
                for (var i=0;i<r.length;i++)
                   html+='<a href="'+r[i][0]+'" title="'+r[i][1]+'"  class="vk_down_icon">'+r[i][1].replace(/-/g,'.')+' </a>';
-               el.innerHTML=html;
+               val(el, html);
             });  
          };      
          
@@ -5970,7 +5970,7 @@ vk_vid_down={
          } else if (yid && type=='vimeo'){ 
             getvimeo(yid)
          }else if(t=='NO_ACCESS'){
-            el.innerHTML='<small class="divide" >'+IDL('NO_ACCESS')+'</small>';
+            val(el, '<small class="divide" >'+IDL('NO_ACCESS')+'</small>');
          } else {
             var obj=JSON.parse(t);
             if (obj.extra=="21"){// 21 - YouTube; 22 - Vimeo; 50 - ivi.ru; 23 - Rutube; 24 - Russia.ru 
@@ -5980,7 +5980,7 @@ vk_vid_down={
             } else if (obj.extra=="50"){// AND ALSO extra=50 - carambatv.ru??? О_о WTF?  //О_о coub.сom  links - http://coub.com/coubs/{coubID}.json
                if ((obj.extra_data||'').indexOf('ivi.ru')!=-1)
                   get_ivi(obj.extra_data);
-               else el.innerHTML='<small class="divide" >'+IDL('NA')+'('+obj.extra+')</small>';
+               else val(el, '<small class="divide" >'+IDL('NA')+'('+obj.extra+')</small>');
             } else if (!obj.extra){
                var html='';
                
@@ -6002,9 +6002,9 @@ vk_vid_down={
                
                
 
-               el.innerHTML = html;
+               val(el, html);
             } else {
-               el.innerHTML='<small class="divide" >'+IDL('NA')+'('+obj.extra+')</small>';
+               val(el, '<small class="divide" >'+IDL('NA')+'('+obj.extra+')</small>');
             }
          }
        });
@@ -6020,17 +6020,17 @@ vk_vid_down={
       el=el.getElementsByTagName('small')[0];//ge("vk_asize"+id);
       if (el && !el.hasAttribute('getsize_ok')){
          el.setAttribute('getsize_ok',true);
-         el.innerHTML=vkLdrMiniImg;
+         val(el, vkLdrMiniImg);
          var reset=setTimeout(function(){
             el.removeAttribute('getsize_ok');
-            el.innerHTML='';
+            val(el, '');
          },WAIT_TIME);
          XFR.post(el.getAttribute('url'),{},function(h,l){
             clearTimeout(reset);
             if (l>0){
-               el.innerHTML=vkFileSize(l,2);
+               val(el, vkFileSize(l,2));
             } else {
-               el.innerHTML='0 byte';
+               val(el, '0 byte');
                el.removeAttribute('getsize_ok');
             }
             
@@ -6220,7 +6220,7 @@ vk_vid_down={
          for (var i=0;i<r.length;i++)
             html+='<a href="'+r[i][0]+'" title="'+r[i][2]+'"  class="clear_fix" onmouseover="vk_vid_down.vkGetVideoSize(this);">'+IDL("download")+' '+r[i][1]+'<small class="fl_r divide" url="'+r[i][0]+'"></small></a>';
             //'<a href="'+vidurl+'" onmouseover="vk_vid_down.vkGetVideoSize(this);">'+IDL("download")+'<small class="fl_r divide" url="'+vidurl+'"></small></a>';
-         ge('vkyoutubelinks').innerHTML='<a id="vkyoutubelinks_show" href="javascript: toggle(\'vkyoutubelinks_list\');">'+IDL('download')+'</a><span id="vkyoutubelinks_list" style="display:none;">'+html+'</span>';      
+         val(ge('vkyoutubelinks'), '<a id="vkyoutubelinks_show" href="javascript: toggle(\'vkyoutubelinks_list\');">'+IDL('download')+'</a><span id="vkyoutubelinks_list" style="display:none;">'+html+'</span>');
       });
       return '<span id="vkyoutubelinks"></span>';
    },
@@ -6268,7 +6268,7 @@ vk_vid_down={
          var html=''; 
          for (var i=0;i<r.length;i++)
             html+='<a href="'+r[i][0]+'" title="'+r[i][2]+'"  class="clear_fix">'+IDL("download")+' ['+r[i][1]+']</a>';
-         ge('vkyoutubelinks').innerHTML='<a id="vkyoutubelinks_show" href="javascript: toggle(\'vkyoutubelinks_list\');">'+IDL('download')+'</a><span id="vkyoutubelinks_list" style="display:none;">'+html+'</span>';      
+         val(ge('vkyoutubelinks'), '<a id="vkyoutubelinks_show" href="javascript: toggle(\'vkyoutubelinks_list\');">'+IDL('download')+'</a><span id="vkyoutubelinks_list" style="display:none;">'+html+'</span>');
       });
       return '<span id="vkyoutubelinks"></span>';
    },
@@ -6330,7 +6330,7 @@ vk_vid_down={
             var inf=vk_videos.get_album();
             var v_el=geByClass('mv_views_count_number',ctrls)[0];
             if (inf && inf[0] && v_el){
-               v_el.innerHTML='<a href="'+inf[1]+'">'+v_el.innerHTML+'</a>';
+               val(v_el, '<a href="'+inf[1]+'">'+v_el.innerHTML+'</a>');
                
             }
             links+='<div class="idd_item">'+vk_vid_down.vkVidDownloadLinks(vkVidVars)+'</div>'; 
@@ -6364,7 +6364,7 @@ vk_au_down={
        td.appendChild(el); 
        td=document.createElement('td');
        td.setAttribute('style',"vertical-align: top;");
-       td.innerHTML='<a href="'+url+'"  download="'+name+'" title="'+name+'" onmousedown="vk_audio.prevent_play();" onclick="vk_audio.prevent_play(); return vkDownloadFile(this);" onmouseover="vkDragOutFile(this);"><div onmouseover_="vk_audio.get_size(\''+id+'\',this)" class="play_new down_btn" id="down'+id+'"></div></a>';
+       val(td, '<a href="'+url+'"  download="'+name+'" title="'+name+'" onmousedown="vk_audio.prevent_play();" onclick="vk_audio.prevent_play(); return vkDownloadFile(this);" onmouseover="vkDragOutFile(this);"><div onmouseover_="vk_audio.get_size(\''+id+'\',this)" class="play_new down_btn" id="down'+id+'"></div></a>');
        tr.appendChild(td);  
        el.setAttribute('vk_ok','1'); 
        if (AUDIO_AUTOLOAD_BITRATE){
@@ -6545,7 +6545,7 @@ if (!window.vkopt_plugins) vkopt_plugins = {};
                 var next_offset = json.offset;
                 vkopt_plugins[PLUGIN_ID].total = json.count;
 
-                vkopt_plugins[PLUGIN_ID].progress_div.innerHTML = vkProgressBar(_offset, vkopt_plugins[PLUGIN_ID].total, 400);  // обновление прогрессбара
+                val(vkopt_plugins[PLUGIN_ID].progress_div, vkProgressBar(_offset, vkopt_plugins[PLUGIN_ID].total, 400));  // обновление прогрессбара
 
                 if (vkopt_plugins[PLUGIN_ID].cur_w.indexOf('photo') > 0) {
                     var images = winToUtf(arr[arr.length - 2]).match(/{"base":[^}]+}/g); // json-объекты, содержащие общее начало ссылок разных размеров и соответствующие концы.
@@ -6593,7 +6593,7 @@ if (!window.vkopt_plugins) vkopt_plugins = {};
                 if (next_offset != vkopt_plugins[PLUGIN_ID].total - 0) {
                     vkopt_plugins[PLUGIN_ID].run(next_offset);
                 } else {
-                    vkopt_plugins[PLUGIN_ID].progress_div.innerHTML = '';
+                    val(vkopt_plugins[PLUGIN_ID].progress_div, '');
                     // генерация списков и табов.
                     var links_joined = vkopt_plugins[PLUGIN_ID].links.join('\n');
                     var links_html = '<div class="vk_mp3_links">\

--- a/source/vk_media.js
+++ b/source/vk_media.js
@@ -1174,7 +1174,7 @@ function vkPVMouseScroll(){
 		vk_ev=ev;*/
 
         vkPVAllowMouseScroll=false;
-        setTimeout("vkPVAllowMouseScroll=true",200);
+        setTimeout(function(){vkPVAllowMouseScroll=true},200);
       }
     };
     var _next=function(e){on_scroll(1,e)};

--- a/source/vk_page.js
+++ b/source/vk_page.js
@@ -163,8 +163,8 @@ vk_profile={
       vk_feed.scroll_posts('page_wall_posts');
    },
    inj:function(){
-      Inj.After('profile.init','});','setTimeout("vkProcessNode();",2);');
-      Inj.End('profile.init','setTimeout("vkOnNewLocation();",2);');   
+      Inj.After('profile.init','});','setTimeout(vkProcessNode,2);');
+      Inj.End('profile.init','setTimeout(vkOnNewLocation,2);');
    },
    wall_notes_link:function(get_count){
       if (get_count){
@@ -454,7 +454,7 @@ function vkWallPhotosLinks(){
 
 
 function vkWall(){
-	Inj.End('FullWall.init','setTimeout("vkOnNewLocation();",2);');
+	Inj.End('FullWall.init','setTimeout(vkOnNewLocation,2);');
    if (getSet(71)=='y') 
       Inj.Before('FullWall.replyTo','if (!v','vkWallReply(post,toMsgId, toId, event, rf,v,replyName); if(false) ');
    //Inj.Before('Wall.replyTo','toggleClass','vk_wall.cancel_reply_btn(post);');  
@@ -1488,7 +1488,7 @@ function vkFriends_get(idx){
 		topMsg('Please, check <a href="/settings?act=vkopt">VkOpt settings</a>');
 		return;
 	}
-    IDFrOnlineTO = setTimeout("vkFriends_get('"+idx+"');", IDFriendTime);
+    IDFrOnlineTO = setTimeout(function(){vkFriends_get(idx);}, IDFriendTime);
   }
   //vkStatus('[Friends '+idx+' Loading]');
   //alert(idx);

--- a/source/vk_page.js
+++ b/source/vk_page.js
@@ -153,7 +153,7 @@ vk_profile={
       if (getSet(61) == 'y') vkProfileGroupBlock();   
       if (MOD_PROFILE_BLOCKS) vkFrProfile();
       //if (getSet(65)=='y') vkShowLastActivity()
-      if (getSet(46) == 'n') vkFriends_get('online');
+      if (getSet(46) == 'n') vkFriends_get('Online');
       if (getSet(47) == 'n') vkFriends_get('common');
       if (getSet(72) == 'y') vk_profile.fr_in_cats();
       vk_profile.only4friends_checkbox();
@@ -1493,7 +1493,7 @@ function vkFriends_get(idx){
   //vkStatus('[Friends '+idx+' Loading]');
   //alert(idx);
   var methods={
-	'online':'friends.getOnline',
+	'Online':'friends.getOnline',
 	'all':'friends.get',
 	'common':'friends.getMutual'
   };
@@ -3950,7 +3950,7 @@ function vk_tag_api(section,url,app_id){
          dk.queue=uncached.concat(dk.queue); //новые в начало очереди
          if (need_run) {
             clearTimeout(dk.timeout);
-            dk.timeout=setTimeout(dk.load_dislikes_info,300);
+            dk.timeout=setTimeout(function(){dk.load_dislikes_info();},300);
          }
       },
       in_cache:function(obj_id){

--- a/source/vk_page.js
+++ b/source/vk_page.js
@@ -182,14 +182,15 @@ vk_profile={
       if (ge('vk_wall_tat_link')) return;
       if (isVisible('page_wall_switch'))  ge('page_wall_header').appendChild(vkCe('span',{"class":'fl_r right_link divide'},'|'));
       var href=ge('page_wall_header').getAttribute('href');
-      ge('page_wall_header').appendChild(vkCe('a',{
-                  "class":'fl_r right_link', 
-                  id:'vk_wall_tat_link',
-                  href:'/wall'+cur.oid+'?with='+vk.id,
-                  onclick:"cancelEvent(event); return nav.go(this, event);",
-                  onmouseover:"this.parentNode.href='/wall"+cur.oid+"?with="+vk.id+"';",
-                  onmouseout:"this.parentNode.href='"+href+"';"
-               },IDL('T-a-T',1)))   
+      var vk_wall_tat_link  = vkCe('a',{
+           "class":'fl_r right_link',
+           id:'vk_wall_tat_link',
+           href:'/wall'+cur.oid+'?with='+vk.id
+      },IDL('T-a-T',1));
+      vk_wall_tat_link.setAttribu7e('onclick',"cancelEvent(event); return nav.go(this, event);");
+      vk_wall_tat_link.setAttribu7e('onmouseover',"this.parentNode.href='/wall"+cur.oid+"?with="+vk.id+"';");
+      vk_wall_tat_link.setAttribu7e('onmouseout',"this.parentNode.href='"+href+"';");
+      ge('page_wall_header').appendChild(vk_wall_tat_link);
    },
    edit_page:function(){
       vk_profile.edit_mid_name();
@@ -218,7 +219,8 @@ vk_profile={
       if (cur.oid!=remixmid() || ge('friends_only') ) return;
       var p=ge('page_add_media');
       if (!p) return;
-      var cb=vkCe('div',{"class":"checkbox fl_l","id":"friends_only","onclick":"checkbox(this);checkbox('status_export',!isChecked(this));checkbox('facebook_export',!isChecked(this));"},'<div></div>'+IDL('OnlyForFriends'));
+      var cb=vkCe('div',{"class":"checkbox fl_l","id":"friends_only"},'<div></div>'+IDL('OnlyForFriends'));
+      cb.setAttribu7e('onclick', "checkbox(this);checkbox('status_export',!isChecked(this));checkbox('facebook_export',!isChecked(this));");
       p.parentNode.insertBefore(cb,p);   
    },
    fav_fr_block:function(is_list){
@@ -445,7 +447,9 @@ function vkWallPhotosLinks(){
    //alert(cur.oid +'\n'+ cur.pid +'\n'+ el +'\n'+ !ge('vk_wall_ph_links') +'\n'+ geByClass('page_media_full_photo')[0]);
    if (cur.oid && cur.pid && el && !ge('vk_wall_ph_links') && (geByClass('page_media_full_photo')[0] || geByClass('page_post_thumb_sized_photo')[0])){
       var listId='wall'+cur.oid+'_'+cur.pid;
-      el.insertBefore(vkCe('a',{id:'vk_wall_ph_links', "class":"fl_r","onclick":"vkGetLinksToPhotos('"+listId+"')"},IDL('Links')),el.firstChild);
+      var vk_wall_ph_links = vkCe('a',{id:'vk_wall_ph_links', "class":"fl_r"},IDL('Links'));
+      vk_wall_ph_links.setAttribu7e('onclick',"vkGetLinksToPhotos('"+listId+"')");
+      el.insertBefore(vk_wall_ph_links, el.firstChild);
       //vkGetLinksToPhotos();
    }
 }
@@ -466,7 +470,9 @@ vk_wall = {
       var title=ge('reply_to_title' + post);
       var inp=ge('reply_to' + post);
       if (!inp || !title || (title.innerHTML || '').indexOf('cancel_reply')!=-1) return;
-      title.appendChild(vkCe('div',{'class':'vk_x_btn',onclick:"vk_wall.cancel_reply('"+post+"');"}));
+      var vk_x_btn = vkCe('div',{'class':'vk_x_btn'});
+      vk_x_btn.setAttribu7e('onclick', "vk_wall.cancel_reply('"+post+"');");
+      title.appendChild(vk_x_btn);
    },
    cancel_reply:function(post){
       var title=ge('reply_to_title' + post);
@@ -480,7 +486,7 @@ vk_wall = {
 
             for (var i = 0; i < anchors.length; i++)  // Меняем обработчики: второй аргумент - оч. большое число
                 if (!hasClass(anchors[i], 'feed_reposts_more_link') && !hasClass(anchors[i], 'wrh_all')) {  // Исключаем ссылки "показать похожие записи" и "Скрыть комментарии"
-                    anchors[i].setAttribute('onclick', anchors[i].getAttribute('onclick').replace("', false", "', 99999"))
+                    anchors[i].setAttribu7e('onclick', anchors[i].getAttribute('onclick').replace("', false", "', 99999"))
                     val(anchors[i].firstElementChild, IDL('showAllComments')+' ('+anchors[i].getAttribute('offs').split('/')[1]+')');
                 }
         }
@@ -491,10 +497,10 @@ vk_wall = {
             for (var i = 0; i < replies_wrap.length; i++) { // Создание кнопочек сортировки
                 var link = vkCe('a', {
                     class: 'fl_r margin5',
-                    tooltip: IDL('sortByLikes'),
-                    onmouseover: "showTooltip(this, {text: this.getAttribute('tooltip')})",
-                    onclick: "vk_wall.sortByLikes('" + replies_wrap[i].id.replace('_wrap', '') + "')"
+                    tooltip: IDL('sortByLikes')
                 }, '<div class="wl_replies_header_toggler_icon fl_r"></div><div class="post_like_icon fl_l"></div>');
+                link.setAttribu7e('onmouseover',"showTooltip(this, {text: this.getAttribute('tooltip')})");
+                link.setAttribu7e('onclick',"vk_wall.sortByLikes('" + replies_wrap[i].id.replace('_wrap', '') + "')");
                 replies_wrap[i].insertBefore(link, replies_wrap[i].firstChild);
             }
         }
@@ -818,11 +824,12 @@ function vkPollResultsBtn(node){
          var m=p.innerHTML.match(/id="post_poll_raw-?\d+_\d+[^>]+value="(-?\d+)_(\d+)"/);
          if (c.innerHTML.indexOf('vkPollCancelAnswer')!=-1) continue;
          c.insertBefore(vkCe('span',{"class":"divider fl_r"},"|"),c.firstChild);
-         c.insertBefore(vkCe('a',{
-                                  "class":"fl_r",
-                                  "href":"#",
-                                  "onclick":"return vkPollCancelAnswer('"+m[1]+"','"+m[2]+"');"
-                                 },IDL('CancelAnswer')),c.firstChild); 
+         var PollCancelEl = vkCe('a',{
+            "class":"fl_r",
+            "href":"#"
+         },IDL('CancelAnswer'));
+         PollCancelEl.setAttribu7e('onclick',"return vkPollCancelAnswer('"+m[1]+"','"+m[2]+"');");
+         c.insertBefore(PollCancelEl,c.firstChild);
       }
 
       if (!el || !c) continue;
@@ -991,8 +998,8 @@ function vkAvkoNav(){
   		profile.showProfilePhoto(avko_num);
 	  }  
 	};  
-    ge('profile_avatar').setAttribute("onmouseover","fadeTo(ge('NextButtAva'),250,0.8);");
-    ge('profile_avatar').setAttribute("onmouseout","fadeTo(ge('NextButtAva'),250,0);");
+    ge('profile_avatar').setAttribu7e("onmouseover","fadeTo(ge('NextButtAva'),250,0.8);");
+    ge('profile_avatar').setAttribu7e("onmouseout","fadeTo(ge('NextButtAva'),250,0);");
 	disableSelectText('avko_next');
 	disableSelectText('avko_prev');
 }
@@ -1378,7 +1385,7 @@ function vkFrProfile(){
   if (c){
     c.setAttribute('title', c.getAttribute('onclick'));
     c.id='profile_full_link';
-    c.setAttribute('onclick','shut("profile_full_info");');
+    c.setAttribu7e('onclick','shut("profile_full_info");');
   }
   var c2 = geByClass('page_list_module')[0];
   if (c2) c2.id="page_list_module";
@@ -1389,7 +1396,7 @@ function vkFrProfile(){
     var hdr=geByClass('p_header_bottom',el)[0];
 	if (!hdr) return;
 	var rlink=geByClass('right_link',el)[0];
-	if (rlink) rlink.setAttribute('onclick',"return nav.go(this.parentNode.parentNode, event)");
+	if (rlink) rlink.setAttribu7e('onclick',"return nav.go(this.parentNode.parentNode, event)");
     var all=hdr.getElementsByTagName('span')[0];
     val(hdr, '<a href="javascript:vkFriends_get(\''+postfix+'\')" id="Fr'+postfix+'Lnk">'+vkopt_brackets(hdr.innerHTML)+'</a>');
     if (all) {
@@ -1409,7 +1416,7 @@ function vkFrProfile(){
     var hdr=geByClass('p_header_bottom',el)[0];
     if (!hdr) return;
 	var rlink=geByClass('right_link',el)[0];
-	if (rlink) rlink.setAttribute('onclick',"return nav.go(this.parentNode.parentNode, event)");
+	if (rlink) rlink.setAttribu7e('onclick',"return nav.go(this.parentNode.parentNode, event)");
     var all=hdr.getElementsByTagName('span')[0];
     if (all) {
        val(all, '<a href="'+el.href+'"  onclick="'+el.getAttribute('onclick')+'">'+all.innerHTML+'</a>');
@@ -1450,7 +1457,8 @@ function vkFrProfile(){
       }
       
       if (key && vk_shuts_mask[key] && EnableShut){
-        var s=vkCe('span',{"class":'fl_l',"onclick":'cancelEvent(event); return shut("'+key+'");'},'<span class="vk_shut_btn"></span>');
+        var s=vkCe('span',{"class":'fl_l'},'<span class="vk_shut_btn"></span>');
+        s.setAttribu7e('onclick','cancelEvent(event); return shut("'+key+'");');
         var p=geByClass('header_top',els[i])[0];
         if (p)  p.insertBefore(s,p.firstChild); 
         addClass(key,'shut_open');
@@ -1599,7 +1607,7 @@ if (!masks[id]) return;
 	   if (ge('profile_full_link') == null) geByClass('profile_info_link')[0].id='profile_full_link';
 	   ge('profile_full_link').setAttribute('title','hide');
   }
-  ge('profile_full_link').setAttribute('onclick','shut(\'profile_full_info\');');
+  ge('profile_full_link').setAttribu7e('onclick','shut(\'profile_full_info\');');
 }
     if (!hasClass(c,"shut")) closed_tabs = isNaN(closed_tabs) ? 0 : closed_tabs & ~masks[id];
     else closed_tabs = isNaN(closed_tabs) ? masks[id] : closed_tabs | masks[id];
@@ -1650,12 +1658,12 @@ vk_graff={
          if (bef && mid){
             bef=bef.getElementsByTagName('a')[0];
             var a=document.createElement('a');
-            a.setAttribute("onfocus","this.blur()");
+            a.setAttribu7e("onfocus","this.blur()");
             a.setAttribute("class"," add_media_item");
             a.setAttribute("id","vk_wall_post_type0");
             a.setAttribute("style","background-image: url(/images/icons/attach_icons.gif); background-position: 3px -151px");
             a.setAttribute("href","#");
-            a.setAttribute("onclick","vk_graff.upload_box("+mid+");return false;");
+            a.setAttribu7e("onclick","vk_graff.upload_box("+mid+");return false;");
             val(a, IDL('LoadGraffiti'));
             bef.parentNode.insertBefore(a,bef.nextSibling);
          }
@@ -1672,7 +1680,8 @@ function vkModGroupBlocks(){
    var el=ge('group_albums');// || ge('public_albums');
    if (el && !ge('gr_photo_browse')){
       el=geByClass('p_header_bottom',el)[0];
-      var a=vkCe('a',{id:'gr_photo_browse', href:'/photos'+cur.oid, onclick:"event.cancelBubble = true; return nav.go(this, event)"},IDL("obzor",1));
+      var a=vkCe('a',{id:'gr_photo_browse', href:'/photos'+cur.oid},IDL("obzor",1));
+      a.setAttribu7e('onclick',"event.cancelBubble = true; return nav.go(this, event)");
       el.appendChild(a);
       //el.innerHTML+='<a href="/photos'+cur.oid+'" onmousedown="event.cancelBubble = true;" onclick="event.cancelBubble = true; return nav.go(this, event);">[ '+IDL("obzor")+' ]</a>';
    }
@@ -1780,22 +1789,20 @@ function vkWikiPages(){
    var pid=cur.pid || nav.objLoc['p'] || /_(\d+)/.exec(nav.strLoc)[1];
    if (p){
       if (p && !ge('vk_add_wiki_page')){
-         p.appendChild(
-            vkCe('a',{
-               "class":class_name,
-               "id":"vk_add_wiki_page",
-               "href":"#",
-               "onclick":"vkWikiNew(); return false;"
-            },IDL('Add')+'<span class="divide">|</span>')
-         );
-         p.appendChild(
-            vkCe('a',{
-               "class":class_name,
-               "id":"vk_add_wiki_page",
-               "href":"#",
-               "onclick":"vkGetWikiCode('"+pid+"','"+gid+"'); return false;"
-            },IDL('Code')+'<span class="divide">|</span>')
-         );
+         var vk_add_wiki_page = vkCe('a',{
+             "class":class_name,
+             "id":"vk_add_wiki_page",
+             "href":"#"
+         },IDL('Add')+'<span class="divide">|</span>');
+         vk_add_wiki_page.setAttribu7e('onclick','vkWikiNew(); return false;');
+         p.appendChild(vk_add_wiki_page);
+         vk_add_wiki_page = vkCe('a',{
+            "class":class_name,
+            "id":"vk_add_wiki_page",
+            "href":"#"
+         },IDL('Code')+'<span class="divide">|</span>');
+         vk_add_wiki_page.setAttribu7e('onclick',"vkGetWikiCode('"+pid+"','"+gid+"'); return false;");
+         p.appendChild(vk_add_wiki_page);
       }   
    } else {
       var end=true;
@@ -1808,22 +1815,21 @@ function vkWikiPages(){
       class_name='';
       
       if (p && !ge('vk_add_wiki_page')){
+         var vk_add_wiki_page = vkCe('a',{
+              "class":class_name,
+              "id":"vk_add_wiki_page",
+              "href":"#"
+            },IDL('Add')+(end?'<span class="divide">|</span>':''));
+         vk_add_wiki_page.setAttribu7e('onclick','vkWikiNew(); return false;');
+         p.insertBefore(vk_add_wiki_page,p.firstChild);
+         vk_add_wiki_page = vkCe('a',{
+            "class":class_name,
+            "id":"vk_add_wiki_page",
+            "href":"#"
+         },IDL('Code')+'<span class="divide">|</span>');
+         vk_add_wiki_page.setAttribu7e('onclick',"vkGetWikiCode('"+pid+"','"+gid+"'); return false;");
          p.insertBefore(
-            vkCe('a',{
-               "class":class_name,
-               "id":"vk_add_wiki_page",
-               "href":"#",
-               "onclick":"vkWikiNew(); return false;"
-            },IDL('Add')+(end?'<span class="divide">|</span>':'')),
-            p.firstChild
-         );
-         p.insertBefore(
-            vkCe('a',{
-               "class":class_name,
-               "id":"vk_add_wiki_page",
-               "href":"#",
-               "onclick":"vkGetWikiCode('"+pid+"','"+gid+"'); return false;"
-            },IDL('Code')+'<span class="divide">|</span>'),
+            vk_add_wiki_page,
             p.firstChild
          );
       }   
@@ -1915,42 +1921,46 @@ function vkDocsPage() {	// Добавляет кнопку "скачать вс�
     if (ge('vkdocslinks')) return;			// Если кнопки уже добавлены, снова не добавлять
     var buttons = ge('docs_side_filter');	// Родительский контейнер всех кнопок, которые справа
     if (buttons) {	// Добавление кнопок
-        buttons.insertBefore(vkCe('div',{	// Кнопка "Скачать всё"
+        var vkdocslinks = vkCe('div', {	// Кнопка "Скачать всё"
                 "id" :	"vkdocslinks",		// id нужен для определения, добавлены ли уже кнопки или нет.
-                "class": "side_filter",
-                "onmousedown": "vkDocsDownloadAll(cur.oid,'imgs');",
-                "onmouseover": "addClass(this, 'side_filter_over');",
-                "onmouseout":  "removeClass(this, 'side_filter_over');"
+                "class": "side_filter"
             },
             IDL('downloadAll')
-        ),ge('docs_section_all'));	// перед кнопкой "все документы"
+        );
+        vkdocslinks.onmousedown = function(){ vkDocsDownloadAll(cur.oid,'imgs'); };
+        vkdocslinks.onmouseover = function(e){ addClass(e.target, 'side_filter_over'); };
+        vkdocslinks.onmouseout = function(e){ removeClass(e.target, 'side_filter_over'); };
+        buttons.insertBefore(vkdocslinks,ge('docs_section_all'));	// перед кнопкой "все документы"
 
-		buttons.insertBefore(vkCe('div',{	// Кнопка "Скачать все гифки"
-				"class": "side_filter",
-				"onmousedown": "vkDocsDownloadAll(cur.oid,'imgs',true);",
-				"onmouseover": "addClass(this, 'side_filter_over');",
-				"onmouseout":  "removeClass(this, 'side_filter_over');"
-			},
-			IDL('downloadAllGifs')
-		),ge('docs_section_all'));	// перед кнопкой "все документы"
+        var downloadAllGifs = vkCe('div',{	// Кнопка "Скачать все гифки"
+                "class": "side_filter"
+            },
+            IDL('downloadAllGifs')
+        );
+        downloadAllGifs.onmousedown = function(){ vkDocsDownloadAll(cur.oid,'imgs',true); };
+        downloadAllGifs.onmouseover = function(e){ addClass(e.target, 'side_filter_over'); };
+        downloadAllGifs.onmouseout = function(e){ removeClass(e.target, 'side_filter_over'); };
+		buttons.insertBefore(downloadAllGifs, ge('docs_section_all'));	// перед кнопкой "все документы"
 
-		buttons.insertBefore(vkCe('div', {	// Кнопка "Сссылки"
-				"class": "side_filter",
-				"onmousedown":	"vkDocsDownloadAll(cur.oid,'links');",
-				"onmouseover":	"addClass(this, 'side_filter_over');",
-				"onmouseout":	"removeClass(this, 'side_filter_over');"
-			},
-			IDL('Links')
-		),ge('docs_section_all'));	// перед кнопкой "все документы"
+        var Links = vkCe('div', {	// Кнопка "Сссылки"
+                "class": "side_filter"
+            },
+            IDL('Links')
+        );
+        Links.onmousedown = function(){ vkDocsDownloadAll(cur.oid,'links'); };
+        Links.onmouseover = function(e){ addClass(e.target, 'side_filter_over'); };
+        Links.onmouseout = function(e){ removeClass(e.target, 'side_filter_over'); };
+		buttons.insertBefore(Links,ge('docs_section_all'));	// перед кнопкой "все документы"
 
-		buttons.insertBefore(vkCe('div', {	// Кнопка "Сссылки на GIF"
-				"class": "side_filter",
-				"onmousedown":	"vkDocsDownloadAll(cur.oid,'links',true);",
-				"onmouseover":	"addClass(this, 'side_filter_over');",
-				"onmouseout":	"removeClass(this, 'side_filter_over');"
-			},
-			IDL('LinksGif')
-		), ge('docs_section_all'));	// перед кнопкой "все документы"
+        var LinksGif = vkCe('div', {	// Кнопка "Сссылки на GIF"
+                "class": "side_filter"
+            },
+            IDL('LinksGif')
+        );
+        LinksGif.onmousedown = function(){ vkDocsDownloadAll(cur.oid,'links', true); };
+        LinksGif.onmouseover = function(e){ addClass(e.target, 'side_filter_over'); };
+        LinksGif.onmouseout = function(e){ removeClass(e.target, 'side_filter_over'); };
+		buttons.insertBefore(LinksGif, ge('docs_section_all'));	// перед кнопкой "все документы"
 	}
 }
 
@@ -3076,7 +3086,9 @@ vk_board={
          var z=geByClass('vk_brd_action',els[i])[0];
          if (!p || !a || z) continue;
          p.appendChild(vkCe('span',{"class":"divide vk_brd_action"},'|'));
-         p.appendChild(vkCe('a',{"href":"#","class":'vk_brd_action',onclick:"return vk_board.get_user_posts('"+a.getAttribute('href')+"','"+els[i].getAttribute('id')+"')"},IDL('PrevPosts')));
+         var vk_brd_action = vkCe('a',{"href":"#","class":'vk_brd_action'},IDL('PrevPosts'));
+         vk_brd_action.setAttribu7e('onclick',"return vk_board.get_user_posts('"+a.getAttribute('href')+"','"+els[i].getAttribute('id')+"')");
+         p.appendChild(vk_brd_action);
       }
    }
 };

--- a/source/vk_page.js
+++ b/source/vk_page.js
@@ -1157,7 +1157,7 @@ function vkDelWallPostComments(oid,pid){
 			cur_offset+=REQ_CNT;
 			vklog(mids);
 			del(scan);
-			//setTimeout(scan,MSG_SCAN_REQ_DELAY);
+			//setTimeout(function(){scan();},MSG_SCAN_REQ_DELAY);
 			
 		});
 	};
@@ -1223,7 +1223,7 @@ function vkCleanWall(oid){
 			cur_offset+=REQ_CNT;
 			vklog(mids);
 			del(scan);
-			//setTimeout(scan,MSG_SCAN_REQ_DELAY);
+			//setTimeout(function(){scan();},MSG_SCAN_REQ_DELAY);
 			
 		});
 	};
@@ -2293,10 +2293,10 @@ vk_groups = {
                      val('gedit_users_summary_' + tab, getLang('groups_found_n_users', founded, true));
                   }
                   ge('gedit_users_rows_members').appendChild(se(found?html:'<span>Error. id'+uid+'</span>'));
-                  if (need_run) setTimeout(queue_process,100); else val(ge('vk_gre_scan_queue'), '');
+                  if (need_run) setTimeout(function(){queue_process();},100); else val(ge('vk_gre_scan_queue'), '');
                },
                onFail:function(){
-                  if (need_run) setTimeout(queue_process,5000); else val(ge('vk_gre_scan_queue'), '');
+                  if (need_run) setTimeout(function(){queue_process();},5000); else val(ge('vk_gre_scan_queue'), '');
                }
             });
       }
@@ -2322,7 +2322,7 @@ vk_groups = {
             val(ge('vk_gre_scan'), vkProgressBar(offset,count,590,IDL('Search')+' %'));
             if (offset<count){
                offset+=PER_REQ;
-               setTimeout(scan,350);
+               setTimeout(function(){scan();},350);
             } else {
                val(ge('vk_gre_scan'), '');
             }
@@ -2368,11 +2368,11 @@ vk_groups = {
             }, {
                onDone: function() {
                   del_offset++;
-                  setTimeout(process,10);         
+                  setTimeout(function(){process();},10);
                },
                onFail:function() {
                   del_offset++;
-                  setTimeout(process,5000);         
+                  setTimeout(function(){process();},5000);
                }
             });
          }
@@ -2432,7 +2432,7 @@ vk_groups = {
             ajax.post('al_groups.php', {act: 'bl_user', mid: ids[del_offset][0], gid: cur.gid, hash: cur.hash}, {
                onDone: function() {
                   del_offset++;
-                  setTimeout(process,10);         
+                  setTimeout(function(){process();},10);
                }
             });  
 
@@ -2460,7 +2460,7 @@ vk_groups = {
                   process();	
                } else {
                   cur_offset+=25; 
-                  setTimeout(scan,10);
+                  setTimeout(function(){scan();},10);
                } 
             }, 
             onFail: function() {}
@@ -2527,7 +2527,7 @@ vk_groups = {
             var _count=ms.shift();
             val(ge('vk_scan_msg'), vkProgressBar(cur_offset,_count,310,IDL('listreq')+' %'));
             for (var i=0;i<ms.length;i++) if (!ms[i].is_admin) mids.push(ms[i].gid);
-            if (cur_offset<_count){	cur_offset+=REQ_CNT; setTimeout(scan,SCAN_REQ_DELAY);} else del(deldone);
+            if (cur_offset<_count){	cur_offset+=REQ_CNT; setTimeout(function(){scan();},SCAN_REQ_DELAY);} else del(deldone);
          });
       };
       
@@ -3057,7 +3057,7 @@ vk_board={
                      }
                      //alert(result.innerHTML);
                   }
-                  setTimeout(scan,300);
+                  setTimeout(function(){scan();},300);
                }
             }); 
          }
@@ -3638,7 +3638,7 @@ function vk_tag_api(section,url,app_id){
                   if (ret<5 && /db_err/.test(t)){
                      ret++;
                      if (vk_DEBUG) console.log('widget_req error... retry '+ret+'... ');
-                     setTimeout(req,3000);
+                     setTimeout(function(){req();},3000);
                   } else 
                      alert('Parse hash error');
                   return;
@@ -3735,7 +3735,7 @@ function vk_tag_api(section,url,app_id){
                      if (vk_DEBUG) console.log('api marks error',obj_ids,err);
                      retry_count++;
                      if (retry_count<5){
-                        setTimeout(get,2000);
+                        setTimeout(function(){get();},2000);
                         if (vk_DEBUG) console.log('api marks error.. wait 2sec and retry.. code:'+err.error_code);
                      } else { 
                         if (vk_DEBUG) console.log('api marks error',obj_ids,err)
@@ -3854,7 +3854,7 @@ function vk_tag_api(section,url,app_id){
                   var r=JSON.parse(t);
                   res=res.concat(r.response);
                   if (uids.length>0) 
-                     setTimeout(scan,340);
+                     setTimeout(function(){scan();},340);
                   else
                      callback(res);
                });
@@ -3988,7 +3988,7 @@ function vk_tag_api(section,url,app_id){
                }
                if (need_continue){
                   //console.log('continue load info',ids,dk.queue);
-                  setTimeout(load,dk.delay);
+                  setTimeout(function(){load();},dk.delay);
                }
             });
          };

--- a/source/vk_page.js
+++ b/source/vk_page.js
@@ -1281,7 +1281,7 @@ function vkFaveProfileBlock(is_list){
    AjGet('/fave?section=users&al=1',function(t){
       var r=t.match(/"faveUsers"\s*:\s*(\[[^\]]+\])/);
       if (r){
-         r=eval('('+r[1]+')');
+         r=JSON.parse(r[1]);
          var onlines=[];
          for(var i=0;i<r.length;i++) if(r[i].online) onlines.push(r[i]);
          var to=3;
@@ -1357,7 +1357,7 @@ function vkProfileGroupBlock(){
             hide('profile_groups');
             return;      
       }
-      data=eval(data[1]);
+      data=JSON.parse(data[1]);
       var count=data.length;
       val(ge('vk_group_block_count'), ' ('+count+')');
       var html='';

--- a/source/vk_page.js
+++ b/source/vk_page.js
@@ -81,12 +81,12 @@ vk_search={
                if (!el) continue;
                u[''+p.uid]=0;
                u[''+p.screen_name]=0;
-               el.innerHTML=vk_search.parse_info(p);//JSON.stringify(p);
+               val(el, vk_search.parse_info(p));//JSON.stringify(p);
                vkProccessLinks(el);
             }
             for (var key in u)
                if (u[key] && ge('vk_exinfo_'+key)) 
-                  ge('vk_exinfo_'+key).innerHTML='';
+                  val(ge('vk_exinfo_'+key), '');
             
          },
          error:function(){}
@@ -169,7 +169,7 @@ vk_profile={
    wall_notes_link:function(get_count){
       if (get_count){
             dApi.call('execute',{code:'return API.notes.get({uid:'+cur.oid+', count:1})[0];'},function(r){ 
-               ge('pr_notes_count').innerHTML=(r.response || '0');
+               val(ge('pr_notes_count'), (r.response || '0'));
             });
       }
       var html='<a class="notes" onclick="return nav.go(this, event);" href="/notes'+cur.oid+'" onmouseover="vk_profile.wall_notes_link(true);">\
@@ -234,11 +234,11 @@ vk_profile={
            <div class="module_body clear_fix" id="vk_favefr_users_content"></div>\
          ';
          var div=vkCe('div',{"class":"module clear people_module",id:"profile_favefr"});
-         div.innerHTML=html;
+         val(div, html);
          var p=ge(is_right_block?'profile_wall':'profile_friends');
          p.parentNode.insertBefore(div,p);  
       }
-      ge('vk_favefr_users_content').innerHTML=vkBigLdrImg;
+      val(ge('vk_favefr_users_content'), vkBigLdrImg);
       if (is_list){
          ge("vk_favefr_all_link").href="javascript:vk_profile.fav_fr_block()";
       } else {
@@ -293,8 +293,8 @@ vk_profile={
             }
          }
          if (ge('vk_favefr_users_content')){
-            ge("vk_favefr_all_link").innerHTML=vkopt_brackets(IDL('FaveFr') +' ('+list.length+')');
-            ge('vk_favefr_users_content').innerHTML=users;
+            val(ge("vk_favefr_all_link"), vkopt_brackets(IDL('FaveFr') +' ('+list.length+')'));
+            val(ge('vk_favefr_users_content'), users);
             vkProcessNodeLite(ge('vk_favefr_users_content'));
          }
          
@@ -310,9 +310,9 @@ function vkLastActivity(uid,callback){
 function vkShowLastActivity(){
    if (!ge('vk_profile_online_la')) 
       ge('title').appendChild(vkCe('b',{id:"vk_profile_online_la", "class":"fl_r", "onclick":"vkShowLastActivity();"}));
-   ge('vk_profile_online_la').innerHTML = "";   
+   val(ge('vk_profile_online_la'), "");
    vkLastActivity(cur.oid,function(info){
-      if (info) ge('vk_profile_online_la').innerHTML = info;
+      if (info) val(ge('vk_profile_online_la'), info);
    });
 }
 */
@@ -481,7 +481,7 @@ vk_wall = {
             for (var i = 0; i < anchors.length; i++)  // Меняем обработчики: второй аргумент - оч. большое число
                 if (!hasClass(anchors[i], 'feed_reposts_more_link') && !hasClass(anchors[i], 'wrh_all')) {  // Исключаем ссылки "показать похожие записи" и "Скрыть комментарии"
                     anchors[i].setAttribute('onclick', anchors[i].getAttribute('onclick').replace("', false", "', 99999"))
-                    anchors[i].firstElementChild.innerHTML = IDL('showAllComments')+' ('+anchors[i].getAttribute('offs').split('/')[1]+')';
+                    val(anchors[i].firstElementChild, IDL('showAllComments')+' ('+anchors[i].getAttribute('offs').split('/')[1]+')');
                 }
         }
         if (getSet(99) == 'y') {    // Функция сортировки комментариев по количеству лайков
@@ -798,7 +798,7 @@ function vkPollVoters(oid,poll_id){
                   if (!users[i].uid) continue;
                   html+='<a class="wk_poll_usr inl_bl" title="'+users[i].first_name+' '+users[i].last_name+'" href="/id'+users[i].uid+'"><img class="wk_poll_usr_photo" src="'+users[i].photo_rec+'" width="30" height="30"></a>'; 
                }
-               el.innerHTML=html;
+               val(el, html);
             }
          }
    }); 
@@ -891,7 +891,7 @@ function vkBDYear(uid,el){
    vk_users.find_age(uid,function(age){
       var txt=age?langNumeric(age, vk_lang["vk_year"]):'N/A';
       removeClass(_el,'fl_r');
-      _el.innerHTML=txt;
+      val(_el, txt);
    },{el:el,width:50});
    return false;
 }
@@ -963,12 +963,12 @@ function vkAvkoNav(){
   var div=document.createElement('div');
   div.setAttribute('style',"width:200px;height:0px;");
   ref.parentNode.insertBefore(div,ref);
-  div.innerHTML='\
+  val(div, '\
           <table width="200px" height="32px" class="NextButtAva ui-corner-bottom" style= "opacity: 0;" id="NextButtAva"><tr>\
                 <td id="avko_prev" class="ui-corner-bl" onclick="avko_list(false);">&#9668;</td>\
                 <td id="avko_zoom" class="zoom_ava" onclick="zoom_profile_photo(cur.options.photos,event); return false;">+</td>\
                 <td id="avko_next" class="ui-corner-br" onclick="avko_list(true);">&#9658;</td>\
-          </tr></table>';
+          </tr></table>');
  zoom_profile_photo=function(ops,event){
 	if (ops && ops!=''){
 		var p=ops[avko_num][1];
@@ -1003,7 +1003,7 @@ function vkUpdWallBtn(){
 	var el=ge('page_wall_posts_count');
 	if (!el || ge('wall_upd_btn')) return;
 	var span=document.createElement('span');
-	span.innerHTML='<a href="#" id="wall_upd_btn" onclick="cancelEvent(event); wall.showMore(0); return false;"> &#8635;</a>';/*&uarr;&darr;*/
+	val(span, '<a href="#" id="wall_upd_btn" onclick="cancelEvent(event); wall.showMore(0); return false;"> &#8635;</a>');/*&uarr;&darr;*/
 	insertAfter(span,el);
 }
 
@@ -1124,10 +1124,10 @@ function vkDelWallPostComments(oid,pid){
 	var del=function(callback){	
 		if (abort) return;
 		var del_count=mids.length;
-		ge('vk_del_msg').innerHTML=vkProgressBar(del_offset,del_count,310,IDL('msgdel')+' %');
+		val(ge('vk_del_msg'), vkProgressBar(del_offset,del_count,310,IDL('msgdel')+' %'));
 		var pid=mids[del_offset];
 		if (!pid){
-			ge('vk_del_msg').innerHTML=vkProgressBar(1,1,310,' ');
+			val(ge('vk_del_msg'), vkProgressBar(1,1,310,' '));
 			del_offset=0;
 			callback();
 		} else
@@ -1140,8 +1140,8 @@ function vkDelWallPostComments(oid,pid){
 	var scan=function(){
 		mids=[];
 		if (cur_offset==0){
-			ge('vk_del_msg').innerHTML=vkProgressBar(1,1,310,' ');
-			ge('vk_scan_msg').innerHTML=vkProgressBar(cur_offset,2,310,IDL('msgreq')+' %');
+			val(ge('vk_del_msg'), vkProgressBar(1,1,310,' '));
+			val(ge('vk_scan_msg'), vkProgressBar(cur_offset,2,310,IDL('msgreq')+' %'));
 		}
 		dApi.call('wall.getComments',{owner_id:oid, post_id:pid, count:100, offset:cur_offset},function(r){
 			if (abort) return;
@@ -1152,7 +1152,7 @@ function vkDelWallPostComments(oid,pid){
 			}
 			if (msg_count==0) msg_count=ms.shift();
 			else ms.shift();
-			ge('vk_scan_msg').innerHTML=vkProgressBar(cur_offset+REQ_CNT,msg_count,310,IDL('msgreq')+' %');
+			val(ge('vk_scan_msg'), vkProgressBar(cur_offset+REQ_CNT,msg_count,310,IDL('msgreq')+' %'));
 			for (var i=0;i<ms.length;i++) mids.push(ms[i].cid);
 			cur_offset+=REQ_CNT;
 			vklog(mids);
@@ -1190,10 +1190,10 @@ function vkCleanWall(oid){
 	var del=function(callback){	
 		if (abort) return;
 		var del_count=mids.length;
-		ge('vk_del_msg').innerHTML=vkProgressBar(del_offset,del_count,310,IDL('msgdel')+' %');
+		val(ge('vk_del_msg'), vkProgressBar(del_offset,del_count,310,IDL('msgdel')+' %'));
 		var pid=mids[del_offset];
 		if (!pid){
-			ge('vk_del_msg').innerHTML=vkProgressBar(1,1,310,' ');
+			val(ge('vk_del_msg'), vkProgressBar(1,1,310,' '));
 			del_offset=0;
 			callback();
 		} else
@@ -1206,8 +1206,8 @@ function vkCleanWall(oid){
 	var scan=function(){
 		mids=[];
 		if (cur_offset==0){
-			ge('vk_del_msg').innerHTML=vkProgressBar(1,1,310,' ');
-			ge('vk_scan_msg').innerHTML=vkProgressBar(cur_offset,2,310,IDL('msgreq')+' %');
+			val(ge('vk_del_msg'), vkProgressBar(1,1,310,' '));
+			val(ge('vk_scan_msg'), vkProgressBar(cur_offset,2,310,IDL('msgreq')+' %'));
 		}
 		dApi.call('wall.get',{owner_id:oid,filter:filter[2],count:REQ_CNT,offset:0+start_offset},function(r){
 			if (abort) return;
@@ -1218,7 +1218,7 @@ function vkCleanWall(oid){
 			}
 			if (msg_count==0) msg_count=ms.shift();
 			else ms.shift();
-			ge('vk_scan_msg').innerHTML=vkProgressBar(cur_offset+REQ_CNT,msg_count,310,IDL('msgreq')+' %');
+			val(ge('vk_scan_msg'), vkProgressBar(cur_offset+REQ_CNT,msg_count,310,IDL('msgreq')+' %'));
 			for (var i=0;i<ms.length;i++) mids.push(ms[i].id);
 			cur_offset+=REQ_CNT;
 			vklog(mids);
@@ -1268,11 +1268,11 @@ function vkFaveProfileBlock(is_list){
       ';
       //html=html.replace('%USERS%',users);
       var div=vkCe('div',{"class":"module clear people_module",id:"profile_fave"});
-      div.innerHTML=html;
+      val(div, html);
       var p=ge(is_right_block?'profile_wall':'profile_friends');
       p.parentNode.insertBefore(div,p);  
    }
-   ge('vk_fave_users_content').innerHTML=vkBigLdrImg;
+   val(ge('vk_fave_users_content'), vkBigLdrImg);
    if (is_list){
       ge("vk_fave_all_link").href="javascript:vkFaveProfileBlock()";
    } else {
@@ -1311,8 +1311,8 @@ function vkFaveProfileBlock(is_list){
             }
          }
          if (ge('vk_fave_users_content')){
-            ge("vk_fave_all_link").innerHTML=vkopt_brackets(IDL('FaveOnline') +' ('+onlines.length+')');
-            ge('vk_fave_users_content').innerHTML=users;
+            val(ge("vk_fave_all_link"), vkopt_brackets(IDL('FaveOnline') +' ('+onlines.length+')'));
+            val(ge('vk_fave_users_content'), users);
             vkProcessNodeLite(ge('vk_fave_users_content'));
          }
       }
@@ -1341,7 +1341,7 @@ function vkProfileGroupBlock(){
       ';
       //html=html.replace('%USERS%',users);
       var div=vkCe('div',{"class":"module clear groups_list_module",id:"profile_groups"});
-      div.innerHTML=html;
+      val(div, html);
       var p=ge(is_right_block?'profile_wall':'profile_friends');
       if (is_right_block)
          p.parentNode.insertBefore(div,ge('profile_wall'));  
@@ -1349,22 +1349,22 @@ function vkProfileGroupBlock(){
          ge('profile_narrow').appendChild(div);
       
    }
-   ge('vk_group_block_content').innerHTML=vkBigLdrImg;
+   val(ge('vk_group_block_content'), vkBigLdrImg);
    AjPost('al_groups.php',{act: 'get_list', mid: cur.oid,tab:'groups',al:1},function(t){
       var data=t.split('<!json>');
       if (!data[1]){
-            ge('vk_group_block_content').innerHTML=IDL('NA');
+            val(ge('vk_group_block_content'), IDL('NA'));
             hide('profile_groups');
             return;      
       }
       data=eval(data[1]);
       var count=data.length;
-      ge('vk_group_block_count').innerHTML=' ('+count+')';
+      val(ge('vk_group_block_count'), ' ('+count+')');
       var html='';
       for (var i=0; i<data.length;i++)
          if (data[i][0]) html+='<a onclick="return nav.go(this, event)" href="'+data[i][3]+'">'+data[i][0]+' </a>';
       
-      ge('vk_group_block_content').innerHTML=html;
+      val(ge('vk_group_block_content'), html);
       vk_highlinghts.groups_block();
       vkProcessNode(ge('vk_group_block_content'));     
    });
@@ -1391,9 +1391,9 @@ function vkFrProfile(){
 	var rlink=geByClass('right_link',el)[0];
 	if (rlink) rlink.setAttribute('onclick',"return nav.go(this.parentNode.parentNode, event)");
     var all=hdr.getElementsByTagName('span')[0];
-    hdr.innerHTML='<a href="javascript:vkFriends_get(\''+postfix+'\')" id="Fr'+postfix+'Lnk">'+vkopt_brackets(hdr.innerHTML)+'</a>';
+    val(hdr, '<a href="javascript:vkFriends_get(\''+postfix+'\')" id="Fr'+postfix+'Lnk">'+vkopt_brackets(hdr.innerHTML)+'</a>');
     if (all) {
-       all.innerHTML='<a href="'+el.href+'" onclick="'+el.getAttribute('onclick')+'">'+all.innerHTML+'</a>';//return nav.go(this, event)
+       val(all, '<a href="'+el.href+'" onclick="'+el.getAttribute('onclick')+'">'+all.innerHTML+'</a>');//return nav.go(this, event)
        var div=document.createElement('div');
        div.className='module_header';
        div.appendChild(all);
@@ -1412,13 +1412,13 @@ function vkFrProfile(){
 	if (rlink) rlink.setAttribute('onclick',"return nav.go(this.parentNode.parentNode, event)");
     var all=hdr.getElementsByTagName('span')[0];
     if (all) {
-       all.innerHTML='<a href="'+el.href+'"  onclick="'+el.getAttribute('onclick')+'">'+all.innerHTML+'</a>';
+       val(all, '<a href="'+el.href+'"  onclick="'+el.getAttribute('onclick')+'">'+all.innerHTML+'</a>');
        var div=document.createElement('div');
        div.className='module_header';
        div.appendChild(all);
        hdr.appendChild(all);
     }
-    //hdr.innerHTML='<a href="javascript:vkFriends_get(\''+postfix+'\')" id="Fr'+postfix+'Lnk">[ '+hdr.innerHTML+' ]</a>';
+    //val(hdr, '<a href="javascript:vkFriends_get(\''+postfix+'\')" id="Fr'+postfix+'Lnk">[ '+hdr.innerHTML+' ]</a>');
     div.appendChild(hdr);
     insertAfter(div,el);
   };
@@ -1430,10 +1430,10 @@ function vkFrProfile(){
   var mod_el={
     'profile_albums':function(el){
         var _el=geByClass('module_body',el)[0];
-        _el.innerHTML='<div align="center"><a href="/photos'+cur.oid+'" onclick="return nav.go(this, event);">'+vkopt_brackets(IDL("obzor"))+'</a> <a href="/photos'+cur.oid+'?act=comments"  onclick="return nav.go(this, event);">'+vkopt_brackets(IDL("komm"))+'</a></div>'+_el.innerHTML;
+        val(_el, '<div align="center"><a href="/photos'+cur.oid+'" onclick="return nav.go(this, event);">'+vkopt_brackets(IDL("obzor"))+'</a> <a href="/photos'+cur.oid+'?act=comments"  onclick="return nav.go(this, event);">'+vkopt_brackets(IDL("komm"))+'</a></div>'+_el.innerHTML);
         var hdr=geByClass('p_header_bottom',el)[0];
         if (!hdr) return;
-        hdr.innerHTML='<a href="javascript:vk_photos.profile_albums_list()">'+vkopt_brackets(hdr.innerHTML)+'</a>';
+        val(hdr, '<a href="javascript:vk_photos.profile_albums_list()">'+vkopt_brackets(hdr.innerHTML)+'</a>');
       }
   };
   for (var i=0; i<els.length;i++)
@@ -1505,7 +1505,7 @@ function vkFriends_get(idx){
   //AjPost('friends.php',{id:cur.oid,filter:idx,qty:'60'},function(r,t){
     //var res=eval('('+t+')');
     var fr=r.response;
-    count_el.innerHTML=count_el.innerHTML.replace(/\d+/,fr.length);
+    val(count_el, count_el.innerHTML.replace(/\d+/,fr.length));
     
     var html='';
     fr=vkSortFrList(fr);
@@ -1515,7 +1515,7 @@ function vkFriends_get(idx){
 			<a href="id'+fr[i].uid+'" '+(vkIsFavUser(fr[i].uid)?'class="vk_faved_user"':'')+'>'+fr[i].full_name+'</a>\
 		   </div>';
     if (fr.length==0) html+='<div align="left" style="margin-left: 10px; width:180px;"><strike>&#x25AA;&nbsp;Nobody&nbsp;OnLine</strike></div>';
-    ge('friends_profile_'+idx).innerHTML=html;
+    val(ge('friends_profile_'+idx), html);
 	vkProcessNodeLite(ge('friends_profile_'+idx));
     //vkStatus('');
     //if (getSet(17) == 'y' || getSet(17) > 0) best(idx);
@@ -1656,7 +1656,7 @@ vk_graff={
             a.setAttribute("style","background-image: url(/images/icons/attach_icons.gif); background-position: 3px -151px");
             a.setAttribute("href","#");
             a.setAttribute("onclick","vk_graff.upload_box("+mid+");return false;");
-            a.innerHTML=IDL('LoadGraffiti');
+            val(a, IDL('LoadGraffiti'));
             bef.parentNode.insertBefore(a,bef.nextSibling);
          }
       };
@@ -1734,10 +1734,10 @@ function vkAudioBlock(load_audios){
    }
    
    if (!load_audios) return;
-   ge('vk_group_audios').innerHTML=block_tpl;
+   val(ge('vk_group_audios'), block_tpl);
    var div=ge('vk_group_audios');
    addClass(div,'empty');
-   ge('vk_audio_content').innerHTML=vkBigLdrImg;   
+   val(ge('vk_audio_content'), vkBigLdrImg);
 	var params={}; 
 	params[cur.oid>0?"uid":"gid"]=Math.abs(cur.oid);
    var is_vkcom=(document.location.href.indexOf('vk.com')!=-1);
@@ -1757,8 +1757,8 @@ function vkAudioBlock(load_audios){
 		}
       
       removeClass(div,'empty');
-      ge('vk_audio_count').innerHTML=list.length;
-      ge('vk_audio_content').innerHTML=html;
+      val(ge('vk_audio_count'), list.length);
+      val(ge('vk_audio_content'), html);
       vk_audio.process_node(div);
 	});
    /*
@@ -2105,7 +2105,7 @@ vk_groups = {
          html=cont_tpl.replace(/%PAGE_LIST%/g,pg)
                       .replace(/%TITLE%/g,info.count)
                       .replace(/%USERS%/g,html);
-         ge('vk_member_list'+gid).innerHTML=html;
+         val(ge('vk_member_list'+gid), html);
          vkProcessNode(ge('vk_member_list'+gid));
       };
       load_info();         
@@ -2129,13 +2129,13 @@ vk_groups = {
          ';
          //html=html.replace('%USERS%',users);
          var div=vkCe('div',{"class":"module clear people_module",id:"vk_group_requests"});
-         div.innerHTML=html;
+         val(div, html);
          var p=ge('group_followers');
          if (!p) return;
          p.parentNode.insertBefore(div,p);
          hide('vk_group_requests');
       }
-      ge('vk_gr_req_users_content').innerHTML=vkBigLdrImg;
+      val(ge('vk_gr_req_users_content'), vkBigLdrImg);
       if (is_list){
          ge("vk_gr_req_all_link").href="javascript:vk_groups.requests_block()";
          addClass('vk_gr_req_all_link','as_list')
@@ -2187,8 +2187,8 @@ vk_groups = {
                }
             }
             if (ge('vk_gr_req_users_content')){
-               ge("vk_gr_req_all_link").innerHTML=vkopt_brackets(getLang('global_X_people',cnt));
-               ge('vk_gr_req_users_content').innerHTML=users;
+               val(ge("vk_gr_req_all_link"), vkopt_brackets(getLang('global_X_people',cnt)));
+               val(ge('vk_gr_req_users_content'), users);
                vkProcessNodeLite(ge('vk_gr_req_users_content'));
             }   
          
@@ -2199,12 +2199,12 @@ vk_groups = {
    request_accept:function(gid,mid,hash){
       var el=ge('vk_gru_act'+mid);
       if (el)
-         el.innerHTML=vkLdrMiniImg;
+         val(el, vkLdrMiniImg);
       ajax.post('groupsedit.php', {act: 'user_action', id: gid, addr: mid, hash: hash, action: 1}, {
          onDone: function() {
             //alert(row);
             if (el){ 
-               el.innerHTML='OK';
+               val(el, 'OK');
                fadeOut(el, 200);
                //hide(el);
                setTimeout(function(){
@@ -2220,12 +2220,12 @@ vk_groups = {
    request_cancel:function(gid,mid,hash){
       var el=ge('vk_gru_act'+mid);
       if (el)
-         el.innerHTML=vkLdrMiniImg;
+         val(el, vkLdrMiniImg);
       ajax.post('groupsedit.php', {act: 'user_action', id: gid, addr: mid, hash: hash, action: -1}, {
          onDone: function() {
             //alert(row);
             if (el){ 
-               el.innerHTML='OK';
+               val(el, 'OK');
                fadeOut(el, 200);
                //hide(el);
                setTimeout(function(){
@@ -2254,7 +2254,7 @@ vk_groups = {
       p.insertBefore(el, p.firstChild); 
    },
    deactivated_edit:function(gid){
-      ge('gedit_users_rows_members').innerHTML='<div id="vk_gre_scan">'+vkBigLdrImg+'</div><div id="vk_gre_scan_queue"></div>';
+      val(ge('gedit_users_rows_members'), '<div id="vk_gre_scan">'+vkBigLdrImg+'</div><div id="vk_gre_scan_queue"></div>');
       hide('gedit_users_more_members');
       var tab=geByClass('summary_tab_sel')[0];
       if (tab){
@@ -2273,12 +2273,12 @@ vk_groups = {
       var deactiv_count=0;
       function queue_process(){
             if (queue.length==0){ 
-               ge('vk_gre_scan_queue').innerHTML='';
+               val(ge('vk_gre_scan_queue'), '');
                return;
             }
             var uid=queue.shift();
             var need_run=(queue.length!=0);
-            ge('vk_gre_scan_queue').innerHTML=vkProgressBar(deactiv_count-queue.length,deactiv_count,590,IDL('Loading')+' %');
+            val(ge('vk_gre_scan_queue'), vkProgressBar(deactiv_count-queue.length,deactiv_count,590,IDL('Loading')+' %'));
             var tab='members';
             ajax.post('groupsedit.php', {
                act: 'get_page',
@@ -2293,10 +2293,10 @@ vk_groups = {
                      val('gedit_users_summary_' + tab, getLang('groups_found_n_users', founded, true));
                   }
                   ge('gedit_users_rows_members').appendChild(se(found?html:'<span>Error. id'+uid+'</span>'));
-                  if (need_run) setTimeout(queue_process,100); else ge('vk_gre_scan_queue').innerHTML='';
+                  if (need_run) setTimeout(queue_process,100); else val(ge('vk_gre_scan_queue'), '');
                },
                onFail:function(){
-                  if (need_run) setTimeout(queue_process,5000); else ge('vk_gre_scan_queue').innerHTML='';
+                  if (need_run) setTimeout(queue_process,5000); else val(ge('vk_gre_scan_queue'), '');
                }
             });
       }
@@ -2319,12 +2319,12 @@ vk_groups = {
             users=null;
             if (need_run) queue_process();
             
-            ge('vk_gre_scan').innerHTML=vkProgressBar(offset,count,590,IDL('Search')+' %');
+            val(ge('vk_gre_scan'), vkProgressBar(offset,count,590,IDL('Search')+' %'));
             if (offset<count){
                offset+=PER_REQ;
                setTimeout(scan,350);
             } else {
-               ge('vk_gre_scan').innerHTML='';
+               val(ge('vk_gre_scan'), '');
             }
             
          });
@@ -2352,7 +2352,7 @@ vk_groups = {
          if (abort) return;
          var del_count=ids.length;
          if (vk_DEBUG) console.log(del_count,del_offset);
-         ge('vk_scan').innerHTML=vkProgressBar(del_offset,del_count,310,IDL('killing... ')+' %');
+         val(ge('vk_scan'), vkProgressBar(del_offset,del_count,310,IDL('killing... ')+' %'));
          var ids_part=ids[del_offset];//.slice(del_offset,del_offset+1);
          if (!ids_part){ 
             box.hide();		
@@ -2422,7 +2422,7 @@ vk_groups = {
          if (abort) return;
          var del_count=ids.length;
          if (vk_DEBUG) console.log(del_count,del_offset);
-         ge('vk_scan').innerHTML=vkProgressBar(del_offset,del_count,310,IDL('unban users... ')+' %');
+         val(ge('vk_scan'), vkProgressBar(del_offset,del_count,310,IDL('unban users... ')+' %'));
          var ids_part=ids[del_offset];//.slice(del_offset,del_offset+1);
          if (!ids_part){ 
             box.hide();		
@@ -2439,7 +2439,7 @@ vk_groups = {
       };
 
       var scan=function(){
-         if (cur_offset==0) ge('vk_scan').innerHTML=vkProgressBar(2,2,310,' scaning... ');
+         if (cur_offset==0) val(ge('vk_scan'), vkProgressBar(2,2,310,' scaning... '));
          //dApi.call('messages.get',{out:is_out?1:0,count:100,offset:cur_offset,preview_length:1},function(r){
          ajax.post(nav.objLoc[0], {act:'blacklist',offset: cur_offset, part: 1}, {
             onDone: function(off,html) {
@@ -2454,7 +2454,7 @@ vk_groups = {
                });
                
                
-               //ge('vk_scan').innerHTML=vkProgressBar(1,1,310,' ');
+               //val(ge('vk_scan'), vkProgressBar(1,1,310,' '));
                ids=ms.slice();
                if (!ms[0] /*|| ids.length>=500*/){ 
                   process();	
@@ -2500,10 +2500,10 @@ vk_groups = {
       var del=function(callback){	
          if (abort) return;
          var del_count=mids.length;
-         ge('vk_del_msg').innerHTML=vkProgressBar(del_offset,del_count,310,IDL('deleting')+' %');
+         val(ge('vk_del_msg'), vkProgressBar(del_offset,del_count,310,IDL('deleting')+' %'));
          var item_id=mids[del_offset];
          if (!item_id){
-            ge('vk_del_msg').innerHTML=vkProgressBar(1,1,310,' ');
+            val(ge('vk_del_msg'), vkProgressBar(1,1,310,' '));
             del_offset=0;
             callback();
          } else
@@ -2515,7 +2515,7 @@ vk_groups = {
       
       var cur_offset=0;
       var scan=function(){
-         if (cur_offset==0) ge('vk_scan_msg').innerHTML=vkProgressBar(cur_offset,2,310,IDL('listreq')+' %');
+         if (cur_offset==0) val(ge('vk_scan_msg'), vkProgressBar(cur_offset,2,310,IDL('listreq')+' %'));
          
          var params={extended:1};
          params['count']=REQ_CNT;
@@ -2525,7 +2525,7 @@ vk_groups = {
             var ms=r.response;
             if (!ms[0]){ del(deldone);	return;	}
             var _count=ms.shift();
-            ge('vk_scan_msg').innerHTML=vkProgressBar(cur_offset,_count,310,IDL('listreq')+' %');
+            val(ge('vk_scan_msg'), vkProgressBar(cur_offset,_count,310,IDL('listreq')+' %'));
             for (var i=0;i<ms.length;i++) if (!ms[i].is_admin) mids.push(ms[i].gid);
             if (cur_offset<_count){	cur_offset+=REQ_CNT; setTimeout(scan,SCAN_REQ_DELAY);} else del(deldone);
          });
@@ -2582,12 +2582,12 @@ function vkGroupDecliner(node){// [name, gid, href, thumb, count, type, hash, fr
 
 function vkGroupLeave(gid,node){
    var p = (node || {}).parentNode;
-   if (p) p.innerHTML=vkLdrImg;
+   if (p) val(p, vkLdrImg);
    dApi.call('groups.leave',{gid:gid},function(r){
       if (r.response==1){
-         if (p) p.innerHTML=IDL('GroupLeft');
+         if (p) val(p, IDL('GroupLeft'));
       } else
-         if (p) p.innerHTML='WTF? O_o';
+         if (p) val(p, 'WTF? O_o');
    });
    return false;
 }
@@ -2645,7 +2645,7 @@ function vkGrLstFilter(){
             //alert(val);
             cur.scrollList.offset=0;
             var cont = ge(cur.scrollList.prefix + cur.scrollList.tab);
-            cont.innerHTML='';
+            val(cont, '');
             GroupsList.showMore();
         }
       });
@@ -2809,10 +2809,10 @@ vk_fave = {
       var del=function(callback){	
          if (abort) return;
          var del_count=ids.length;
-         ge('vk_del_info').innerHTML=vkProgressBar(del_offset,del_count,310,IDL('deleting')+' %');
+         val(ge('vk_del_info'), vkProgressBar(del_offset,del_count,310,IDL('deleting')+' %'));
          var obj=ids[del_offset];
          if (!obj){
-            ge('vk_del_info').innerHTML=vkProgressBar(1,1,310,' ');
+            val(ge('vk_del_info'), vkProgressBar(1,1,310,' '));
             del_offset=0;
             callback();
          } else
@@ -2825,8 +2825,8 @@ vk_fave = {
       var scan=function(){
          ids=[];
          if (cur_offset==0){
-            ge('vk_del_info').innerHTML=vkProgressBar(1,1,310,' ');
-            ge('vk_scan_info').innerHTML=vkProgressBar(cur_offset,2,310,IDL('listreq')+' %');
+            val(ge('vk_del_info'), vkProgressBar(1,1,310,' '));
+            val(ge('vk_scan_info'), vkProgressBar(cur_offset,2,310,IDL('listreq')+' %'));
          }
          dApi.call('fave.getPhotos',{offset:0/*cur_offset*/,count:REQ_CNT},function(r){
             //var data=r.response;
@@ -2839,7 +2839,7 @@ vk_fave = {
             }
             if (info_count==0) info_count=data.shift();
             else data.shift();
-            ge('vk_scan_info').innerHTML=vkProgressBar(cur_offset+REQ_CNT,info_count,310,IDL('listreq')+' %');
+            val(ge('vk_scan_info'), vkProgressBar(cur_offset+REQ_CNT,info_count,310,IDL('listreq')+' %'));
             for (var i=0;i<data.length;i++) ids.push([data[i].owner_id,data[i].pid]);
             cur_offset+=REQ_CNT;
             //vklog(ids);
@@ -2872,10 +2872,10 @@ vk_fave = {
       var del=function(callback){	
          if (abort) return;
          var del_count=ids.length;
-         ge('vk_del_info').innerHTML=vkProgressBar(del_offset,del_count,310,IDL('deleting')+' %');
+         val(ge('vk_del_info'), vkProgressBar(del_offset,del_count,310,IDL('deleting')+' %'));
          var obj=ids[del_offset];
          if (!obj){
-            ge('vk_del_info').innerHTML=vkProgressBar(1,1,310,' ');
+            val(ge('vk_del_info'), vkProgressBar(1,1,310,' '));
             del_offset=0;
             callback();
          } else
@@ -2888,8 +2888,8 @@ vk_fave = {
       var scan=function(){
          ids=[];
          if (cur_offset==0){
-            ge('vk_del_info').innerHTML=vkProgressBar(1,1,310,' ');
-            ge('vk_scan_info').innerHTML=vkProgressBar(cur_offset,2,310,IDL('listreq')+' %');
+            val(ge('vk_del_info'), vkProgressBar(1,1,310,' '));
+            val(ge('vk_scan_info'), vkProgressBar(cur_offset,2,310,IDL('listreq')+' %'));
          }
          dApi.call('fave.getVideos',{offset:0/*cur_offset*/,count:REQ_CNT},function(r){
             //var data=r.response;
@@ -2902,7 +2902,7 @@ vk_fave = {
             }
             if (info_count==0) info_count=data.shift();
             else data.shift();
-            ge('vk_scan_info').innerHTML=vkProgressBar(cur_offset+REQ_CNT,info_count,310,IDL('listreq')+' %');
+            val(ge('vk_scan_info'), vkProgressBar(cur_offset+REQ_CNT,info_count,310,IDL('listreq')+' %'));
             for (var i=0;i<data.length;i++) ids.push([data[i].owner_id,data[i].vid]);
             cur_offset+=REQ_CNT;
             //vklog(ids);
@@ -2935,10 +2935,10 @@ vk_fave = {
       var del=function(callback){	
          if (abort) return;
          var del_count=ids.length;
-         ge('vk_del_info').innerHTML=vkProgressBar(del_offset,del_count,310,IDL('deleting')+' %');
+         val(ge('vk_del_info'), vkProgressBar(del_offset,del_count,310,IDL('deleting')+' %'));
          var obj=ids[del_offset];
          if (!obj){
-            ge('vk_del_info').innerHTML=vkProgressBar(1,1,310,' ');
+            val(ge('vk_del_info'), vkProgressBar(1,1,310,' '));
             del_offset=0;
             callback();
          } else
@@ -2951,8 +2951,8 @@ vk_fave = {
       var scan=function(){
          ids=[];
          if (cur_offset==0){
-            ge('vk_del_info').innerHTML=vkProgressBar(1,1,310,' ');
-            ge('vk_scan_info').innerHTML=vkProgressBar(cur_offset,2,310,IDL('listreq')+' %');
+            val(ge('vk_del_info'), vkProgressBar(1,1,310,' '));
+            val(ge('vk_scan_info'), vkProgressBar(cur_offset,2,310,IDL('listreq')+' %'));
          }
          dApi.call('fave.getPosts',{offset:0/*cur_offset*/,count:REQ_CNT},function(r){
             //var data=r.response;
@@ -2965,7 +2965,7 @@ vk_fave = {
             }
             if (info_count==0) info_count=data.shift();
             else data.shift();
-            ge('vk_scan_info').innerHTML=vkProgressBar(cur_offset+REQ_CNT,info_count,310,IDL('listreq')+' %');
+            val(ge('vk_scan_info'), vkProgressBar(cur_offset+REQ_CNT,info_count,310,IDL('listreq')+' %'));
             for (var i=0;i<data.length;i++) ids.push([data[i].to_id,data[i].id]);
             cur_offset+=REQ_CNT;
             //vklog(ids);
@@ -3019,7 +3019,7 @@ vk_board={
       p.insertBefore(panel,p.firstChild);
       var btn=geByTag1('button');
       var status=function(){
-         ge(idprogr).innerHTML=vkProgressBar(start_offset-cur_offset,start_offset,310, 'Scaning... %'); 
+         val(ge(idprogr), vkProgressBar(start_offset-cur_offset,start_offset,310, 'Scaning... %'));
       };
       var done=function(){
          hide(idctrls);
@@ -3543,10 +3543,10 @@ vk_feed={
                 if (r.response && r.response[0]) {
                     var u = r.response[0];
                     // вместо надписи о том, что ничего не найдено, вставить строчку с владельцем странички
-                    geByClass('olist')[0].innerHTML = tpl.replace(/%UID/g, u.uid || '-' + u.gid)
+                    val(geByClass('olist')[0], tpl.replace(/%UID/g, u.uid || '-' + u.gid)
                         .replace(/%LINK/g, u.screen_name)
                         .replace(/%PHOTO/g, u.photo_50 || u.photo)
-                        .replace(/%NAME/g, u.name || u.first_name + ' ' + u.last_name);
+                        .replace(/%NAME/g, u.name || u.first_name + ' ' + u.last_name));
                     val(input, ''); // очистить поле ввода (а надо ли?)
                 }
             });
@@ -4006,7 +4006,7 @@ function vk_tag_api(section,url,app_id){
          var my=val<0;
          val=Math.abs(val);
          if (val>0)
-            ge('dislike_count'+obj_id).innerHTML=val;
+            val(ge('dislike_count'+obj_id), val);
          (my?addClass:removeClass)(ge('dislike_icon' + obj_id),'my_dislike');
          (val>0?removeClass:addClass)(ge('dislike_icon' + obj_id),'no_dislikes'); 
          return true;
@@ -4226,8 +4226,8 @@ function vk_tag_api(section,url,app_id){
                              .replace(/%AVA%/g,users[i].photo_rec);
             }
             html='<tr>'+html+'</tr>';
-            ge('dislike_table_'+post).innerHTML=html;
-            ge('dislike_title_'+post).innerHTML=langNumeric(info.count,IDL('users_dislike'));
+            val(ge('dislike_table_'+post), html);
+            val(ge('dislike_title_'+post), langNumeric(info.count,IDL('users_dislike')));
             vkProcessNode(ge('dislike_table_'+post));
          };
          if (cnt>0 || act){
@@ -4377,7 +4377,7 @@ function vk_tag_api(section,url,app_id){
             html=cont_tpl.replace(/%PAGE_LIST%/g,pg)
                          .replace(/%TITLE%/g,langNumeric(info.count,IDL('users_dislike')))
                          .replace(/%USERS%/g,html);
-            ge('dislike_list'+post).innerHTML=html;
+            val(ge('dislike_list'+post), html);
             vkProcessNode(ge('dislike_list'+post));
          };
          load_info();         

--- a/source/vk_settings.js
+++ b/source/vk_settings.js
@@ -165,7 +165,7 @@ function vkSettingsPage(){
 function vkLoadVkoptConfigFromFile(){
   vkLoadTxt(function(txt){
 	try {
-     var cfg=eval('('+txt+')');
+     var cfg=JSON.parse(txt);
 	  /*alert(print_r(cfg));*/
 	  for (var key in cfg) if (cfg[key]) 
 		vksetCookie(key,cfg[key]);
@@ -509,11 +509,7 @@ function ReadWallsCfg(){
   try {
       return JSON.parse(vkGetVal('WallsID')) || {}; //{"1244":"Name", ... }
   } catch (e) {
-      try {
-          return eval(vkGetVal('WallsID')) || {};
-      } catch (e) {
           return {};
-      }
   }
 }
 function SetWallsCfg(cfg){
@@ -1327,7 +1323,7 @@ function vkResetSounds(){
 function vkLoadSoundsFromFile(){
     vkLoadTxt(function(txt){
     try {
-      var cfg=eval('('+txt+')');
+      var cfg=JSON.parse(txt);
 	  //alert('qwe');
       for (var key in cfg) if (cfg[key] && vkSoundsRes[key] && key!='Name') 
         vkSetVal('sound_'+key,cfg[key]);

--- a/source/vk_settings.js
+++ b/source/vk_settings.js
@@ -105,35 +105,35 @@ function vkLocalStorageMan(ret){
   };
   vkLsDelVal=function(key_){
     localStorage.removeItem(key_);
-    ge('LsList').innerHTML=vkGetLsList();
-    ge("LsEditNode").innerHTML='';
+    val(ge('LsList'), vkGetLsList());
+    val(ge("LsEditNode"), '');
   };
   vkLsSaveVal=function(key_){
     localStorage[key_]=ge('LsValEdit').value;
-    ge('LsList').innerHTML=vkGetLsList();
-    //ge("LsEditNode").innerHTML='';
+    val(ge('LsList'), vkGetLsList());
+    //val(ge("LsEditNode"), '');
   };  
   vkLsNewKey=function(key_){
     localStorage.removeItem(key_);
-    ge('LsList').innerHTML=vkGetLsList();
+    val(ge('LsList'), vkGetLsList());
     var el=ge("LsEditNode");
-    el.innerHTML='<u>Key:</u> <input type="text" id="LsValNameEdit"/><br>'+
+    val(el, '<u>Key:</u> <input type="text" id="LsValNameEdit"/><br>'+
                  '<u>Value:</u><br><textarea id="LsValEdit" rows=5 cols=86  style_="height:100px; width:100%;"></textarea><br>'+
-                 '<div style="padding-top:5px;">'+vkRoundButton(['Save key',"javascript:vkLsSaveNewVal()"])+'</div>';
+                 '<div style="padding-top:5px;">'+vkRoundButton(['Save key',"javascript:vkLsSaveNewVal()"])+'</div>');
 
   };
   vkLsSaveNewVal=function(){
     var key_=ge('LsValNameEdit').value;
     localStorage[key_]=ge('LsValEdit').value;
-    ge('LsList').innerHTML=vkGetLsList();
+    val(ge('LsList'), vkGetLsList());
     vkLsEdit(key_);
-    //ge("LsEditNode").innerHTML='';
+    //val(ge("LsEditNode"), '');
   };
   vkLsEdit=function(_key){
     var el=ge("LsEditNode");
-    el.innerHTML='<u>Key:</u> <b>'+_key+'</b><br>'+
+    val(el, '<u>Key:</u> <b>'+_key+'</b><br>'+
                  '<u>Value:</u><br><textarea id="LsValEdit" rows=5 cols=86  style_="height:100px; width:100%;">'+localStorage[_key]+'</textarea><br>'+
-                 '<div style="padding-top:5px;">'+vkRoundButton(['Save key',"javascript:vkLsSaveVal('"+_key+"')"],['Delete key',"javascript:vkLsDelVal('"+_key+"')"])+'</div>';
+                 '<div style="padding-top:5px;">'+vkRoundButton(['Save key',"javascript:vkLsSaveVal('"+_key+"')"],['Delete key',"javascript:vkLsDelVal('"+_key+"')"])+'</div>');
     el=geByClass('lsrow_sel')[0];
     if (el) el.className='lsrow';
     ge('lsrow_'+_key).className='lsrow_sel';
@@ -154,11 +154,11 @@ function vkSettingsPage(){
 	vkOpt_toogle();
 	if (!ge('vkopt_settings_tab') && ge('settings_filters')){
 		var li=vkCe('li',{id:'vkopt_settings_tab'});
-		li.innerHTML='\
+		val(li, '\
 			<a href="/settings?act=vkopt" onclick="return checkEvent(event)" onmousedown="return vkShowSettings();" title="VkOpt">\
 			<b class="tl1"><b></b></b><b class="tl2"></b>\
 			<b class="tab_word">&nbsp;</b>\
-			</a>'; 
+			</a>');
 		ge('settings_filters').appendChild(li);
 	}
 }
@@ -559,7 +559,7 @@ function GenWallList(el){   // Генерация списка записей в
       lnk = "wall" + id;
       whtml += '<div id="wit' + id + '" style="width:170px"><a style="position:relative; left:100%" onclick="vkRemWall(this)" title="'+IDL('phDel')+'" i="' + id + '">x</a>' + (++i) + ') <a href="' + lnk + '">' + wall_list[id] + '</a></div>';
   }
-  if (!el) {return whtml;} else {el.innerHTML=whtml;}
+  if (!el) {return whtml;} else {val(el, whtml);}
 }
 //end wallmgr
 
@@ -800,7 +800,7 @@ vk_settings = {
    },
    filter:function(s){
       if (!s || trim(s)==''){
-         ge('vksets_search_result').innerHTML='';
+         val(ge('vksets_search_result'), '');
          hide('vksets_clear_inp');
          show('vksets_stoggle_btn');
          vkMakeSettings('vksetts_tabs');
@@ -839,9 +839,9 @@ vk_settings = {
        }   
      }
      //console.log(sets);
-     ge('vksetts_tabs').innerHTML='';
-     ge('vksets_search_result').innerHTML='<div class="sett_cat_header">'+cat+' ('+sets.length+')</div>'+vkGetSettings(sets,allsett)+
-                              (s=='EXTRA'?'<div class="sett_cat_header">Advanced/unstable settings. WARNING! DANGER!</div>'+vk_settings.cfg_override_edit():'');
+     val(ge('vksetts_tabs'), '');
+     val(ge('vksets_search_result'), '<div class="sett_cat_header">'+cat+' ('+sets.length+')</div>'+vkGetSettings(sets,allsett)+
+                              (s=='EXTRA'?'<div class="sett_cat_header">Advanced/unstable settings. WARNING! DANGER!</div>'+vk_settings.cfg_override_edit():''));
 
    },
    cfg_override: function(){
@@ -927,7 +927,7 @@ vk_settings = {
             window[VKOPT_CFG_LIST[i]] = window.VKOPT_CFG_LIST_ORIG[VKOPT_CFG_LIST[i]];
          } 
          vkSetVal('vk_cfg_override','{}');
-         ge('vk_adv_settings_content').parentNode.innerHTML=vk_settings.cfg_override_edit();
+         val(ge('vk_adv_settings_content').parentNode, vk_settings.cfg_override_edit());
       }
    }
 };
@@ -964,9 +964,9 @@ function vkSwitchSet(id,set,ex){
             //(type=='on' && sett[id]=='y') || (type=='off' && sett[id]=='n')
           }
         } 
-    el.innerHTML=html;
+    val(el, html);
   } else {
-    ge('vkcurset'+id).innerHTML=set;
+    val(ge('vkcurset'+id), set);
   }
   allsett[0]=sett.join('');
   vksetCookie('remixbit',allsett.join('-'));
@@ -1093,7 +1093,7 @@ function vkMakeSettings(el){
             setTimeout(f,100);
             return;
          }
-         ge('vk_sound_vol_label').innerHTML=IDL('Volume')+": "+p+"%";
+         val(ge('vk_sound_vol_label'), IDL('Volume')+": "+p+"%");
       };
       f(); 
       if (!u){
@@ -1145,7 +1145,7 @@ function vkMakeSettings(el){
   vkRemixBitS=function(){return "DefSetBits='"+vkgetCookie('remixbit')+"';";};
   tabs[0].active=true;
   var html=vkMakeContTabs(tabs);
-  if (el) ge(el).innerHTML=html;//'<div id="vksetts_search"></div><div id="vksetts_tabs">'+html+'</div>';//vkGetSettings(vkoptSets['Media'],allsett);
+  if (el) val(ge(el), html);//'<div id="vksetts_search"></div><div id="vksetts_tabs">'+html+'</div>';//vkGetSettings(vkoptSets['Media'],allsett);
   else return html;
 }
 
@@ -1171,8 +1171,8 @@ function vkShowSettings(box){
   if (!box){
     show('header');
 	document.title='[ VkOpt ['+String(vVersion).split('').join('.')+'] settings ]';
-    ge('header').innerHTML='<h1>'+header+'</h1>';
-    ge('content').innerHTML=tpl.replace(/%html/g,'');
+    val(ge('header'), '<h1>'+header+'</h1>');
+    val(ge('content'), tpl.replace(/%html/g,''));
     vkMakeSettings('vksetts_tabs');
   } else {
     var html=tpl.replace(/%html/g,vkMakeSettings());
@@ -1229,12 +1229,12 @@ function vkSaveSettingsOnServer(){
    code="return {"+code.join(',')+"};";
    //alert(code);
    dApi.call('execute',{code:code},function(r){
-      ge('cfg_on_serv_info').innerHTML='<div class="vk_cfg_info">'+IDL('seCfgBackupSaved')+'</div>';
+      val(ge('cfg_on_serv_info'), '<div class="vk_cfg_info">'+IDL('seCfgBackupSaved')+'</div>');
       if (vk_DEBUG) console.log('Store vkopt settings result:',r);
    });
    /*
 	dApi.call('storage.set',{key:'remixbits',value:sett},function(r){
-		ge('cfg_on_serv_info').innerHTML='<div class="vk_cfg_info">'+IDL('seCfgBackupSaved')+'</div>';
+		val(ge('cfg_on_serv_info'), '<div class="vk_cfg_info">'+IDL('seCfgBackupSaved')+'</div>');
 	});
  	var FavList=vkGetVal('FavList');
    if(FavList && FavList!='')  dApi.call('storage.set',{key:'FavList',value:FavList},function(){});  
@@ -1249,14 +1249,14 @@ function vkLoadSettingsFromServer(check,callback){
 				var cfg=r.response.split('|');
 				if (cfg[1] && parseInt(cfg[1])){
 					var date=(new Date(parseInt(cfg[1])*1000)).format("dd.mm.yyyy (HH:MM:ss)");
-					ge('cfg_on_serv_info').innerHTML='<div class="vk_cfg_info">'+IDL('seCfgBackupDate')+' <b>'+date+'</b> </div>';
+					val(ge('cfg_on_serv_info'), '<div class="vk_cfg_info">'+IDL('seCfgBackupDate')+' <b>'+date+'</b> </div>');
                if (callback) callback(true);
 				} else {
-					ge('cfg_on_serv_info').innerHTML='<div class="vk_cfg_warn">'+IDL('seCfgNoBackup')+' #1</div>';
+					val(ge('cfg_on_serv_info'), '<div class="vk_cfg_warn">'+IDL('seCfgNoBackup')+' #1</div>');
                if (callback) callback(false);
 				}
 			} else {
-				ge('cfg_on_serv_info').innerHTML='<div class="vk_cfg_warn">'+IDL('seCfgNoBackup')+' #2</div>';
+				val(ge('cfg_on_serv_info'), '<div class="vk_cfg_warn">'+IDL('seCfgNoBackup')+' #2</div>');
             if (callback) callback(false);
 			}		
       } else {
@@ -1274,11 +1274,11 @@ function vkLoadSettingsFromServer(check,callback){
                vksetCookie('vklang',scfg['vklang']);
             
             // FavList
-            var val=scfg['FavList'];
+            var _val=scfg['FavList'];
             var FavList=vkGetVal('FavList');
-            if (val && val!='' && FavList!=val){
-               if(!FavList || FavList=='') vkSetVal('FavList',val);
-               else if(confirm(IDL('FavListRelace'))) vkSetVal('FavList',val);
+            if (_val && _val!='' && FavList!=_val){
+               if(!FavList || FavList=='') vkSetVal('FavList',_val);
+               else if(confirm(IDL('FavListRelace'))) vkSetVal('FavList',_val);
             }   
             if (scfg['menu_custom_links']) vkSetVal('menu_custom_links',scfg['menu_custom_links']);
             // SkinManager settings
@@ -1288,9 +1288,9 @@ function vkLoadSettingsFromServer(check,callback){
             if (scfg['vk_sounds_vol']) vkSetVal("vk_sounds_vol",scfg['vk_sounds_vol']);
             if (scfg['WallsID']) vkSetVal("WallsID",scfg['WallsID']);
 
-				ge('cfg_on_serv_info').innerHTML='<div class="vk_cfg_info">'+IDL('seCfgRestored')+'</div>';
+				val(ge('cfg_on_serv_info'), '<div class="vk_cfg_info">'+IDL('seCfgRestored')+'</div>');
 			} else {
-				ge('cfg_on_serv_info').innerHTML='<div class="vk_cfg_error">'+IDL('seCfgLoadError')+' #0</div>';
+				val(ge('cfg_on_serv_info'), '<div class="vk_cfg_error">'+IDL('seCfgLoadError')+' #0</div>');
 			}
          /*
          dApi.call('storage.get',{key:'FavList'},function(r){
@@ -1320,7 +1320,7 @@ function vkUpdateSounds(on_command){
 function vkResetSounds(){
   for (var key in vkSoundsRes) vkSetVal('sound_'+key,'');
   vkSetVal('sounds_name','');
-  if(ge('vkSndThemeName')) ge('vkSndThemeName').innerHTML=IDL('Default');
+  if(ge('vkSndThemeName')) val(ge('vkSndThemeName'), IDL('Default'));
   vkUpdateSounds();
 }
 
@@ -1335,7 +1335,7 @@ function vkLoadSoundsFromFile(){
       var tname=cfg['Name']?cfg['Name']:'N/A';
       tname=replaceChars(tname);
       vkSetVal('sounds_name',tname);
-      if(ge('vkSndThemeName')) ge('vkSndThemeName').innerHTML=tname;
+      if(ge('vkSndThemeName')) val(ge('vkSndThemeName'), tname);
       
       alert(IDL('SoundsThemeLoaded'));
 	  vkUpdateSounds();

--- a/source/vk_settings.js
+++ b/source/vk_settings.js
@@ -19,7 +19,7 @@ function InstallRelease(){
   
   if (!window.vk || !vk.id) return;
   if (isNewLib() && !window.lastWindowWidth){
-      setTimeout(InstallRelease,50);
+      setTimeout(function(){InstallRelease();},50);
       return;
   }  
   var err=[];
@@ -1090,7 +1090,7 @@ function vkMakeSettings(el){
    var changevolume=function(v,p,u){
       var f=function(){
          if (!ge('vk_sound_vol_label')){
-            setTimeout(f,100);
+            setTimeout(function(){f();},100);
             return;
          }
          val(ge('vk_sound_vol_label'), IDL('Volume')+": "+p+"%");

--- a/source/vk_settings.js
+++ b/source/vk_settings.js
@@ -721,7 +721,7 @@ function vkInitSettings(){
    //LAST 105
 
    vkSetsType={
-      "on"  :[IDL('on'),'y'],
+      "on"  :[IDL('On'),'y'],
       "off" :[IDL('of'),'n'],
       "ru"  :[IDL('ru'),'y'],
       "au"  :[IDL('au'),'n'],

--- a/source/vk_skinman.js
+++ b/source/vk_skinman.js
@@ -252,7 +252,7 @@ vkSkinnerInit();
 
 function vkSwichCSS(code){
   vk_LSSetVal('VK_CURRENT_CSS_CODE',code);
-  ge('vkStyleNode').innerHTML=code;
+  val(ge('vkStyleNode'), code);
 }
 
 function vkSwichStyle(url,el,js){
@@ -310,7 +310,7 @@ function vkPrepareCats(skins){ // it's PIZDEC! Don't translate to Russian
 function vkCatNavigate(elem){
   var cat=elem.getAttribute("category");
   vkShowSkinMan(cat);
-  ge("header").innerHTML='<h1>'+IDL("SkinMan")+' | '+cat+'</h1>';
+  val(ge("header"), '<h1>'+IDL("SkinMan")+' | '+cat+'</h1>');
   return false;
 }
 function vkMakeCatMenu(cats){
@@ -441,7 +441,7 @@ function vkShowSkinMan(filter,page){
              '</div>'+
              
             '</div>';
-	  ge("content").innerHTML=html+'<div class="box_loader"></div>';
+	  val(ge("content"), html+'<div class="box_loader"></div>');
       var nows= new  Date(); 
       var datsig=nows.getYear()+"_"+nows.getMonth()+"_"+nows.getDate()+"_";
       datsig+=Math.floor(nows.getHours()/4); //raz v 4 chasa      
@@ -532,9 +532,9 @@ function vkShowSkinMan(filter,page){
   }
 
   html+='</div></div></div>';
-  ge("content").innerHTML=html;
-  ge("toppages").innerHTML=vkMakePageListS(page,Math.ceil(vkMyStyles.length/VK_THEMES_ON_PAGE)-1,"javascript:vkShowSkinMan("+(filter || false)+",%%);","vkShowSkinMan("+(filter || false)+",%%); return false;");
-  ge("header").innerHTML='<h1>'+IDL("SkinMan")+'</h1>';
+  val(ge("content"), html);
+  val(ge("toppages"), vkMakePageListS(page,Math.ceil(vkMyStyles.length/VK_THEMES_ON_PAGE)-1,"javascript:vkShowSkinMan("+(filter || false)+",%%);","vkShowSkinMan("+(filter || false)+",%%); return false;"));
+  val(ge("header"), '<h1>'+IDL("SkinMan")+'</h1>');
   vk_skinman.likes_load(pids);
   return false;
 }
@@ -583,7 +583,7 @@ vk_skinman={
             
             var icon=ge('s_like_icon'+pid),
                 count=ge('s_like_count'+pid);
-            if (count) count.innerHTML=cnt>0?cnt:'';
+            if (count) val(count, cnt>0?cnt:'');
             if (icon && my_like) addClass(icon,'my_like');
          }
       })
@@ -598,7 +598,7 @@ vk_skinman={
       var act=hasClass(icon,'my_like');
       (act?removeClass:addClass)(icon,'my_like');
       dApi.call(act?'likes.delete':'likes.add',{type:'photo', owner_id:oid,item_id:item_id},function(r){
-         count.innerHTML=r.response.likes;
+         val(count, r.response.likes);
          if (icon.parentNode.tt) icon.parentNode.tt.destroy();
          //icon.parentNode.tt=null;
          //vk_skinman.like_over(pid);
@@ -653,10 +653,10 @@ function vkSkinManInit(){
   div.id='chStyle';
   div.setAttribute("style","position:fixed; top:0px; left:0px; z-index:999;");
   var arrow_style='font-size:11px; font-weight:normal; margin: 0px; line-height:15px; padding:0px 0px 0px 0px;';
-  div.innerHTML='<div id="Strelki"><table><tr>'+
+  val(div, '<div id="Strelki"><table><tr>'+
      // '<td><div style="'+arrow_style+'"><a href="#" style="'+arrow_style+'" onclick="return vkSwichStyle(prompt());">[S]</a></div></td>'+
       '<td><div style="'+arrow_style+'"><a href="#" style="'+arrow_style+'" onclick="hide(this); return vkShowSkinMan();">[&uarr;]</a></div></td>'+
-      '</tr></table></div>';
+      '</tr></table></div>');
   body.appendChild(div);
   if (/\?skinman/.test(location.href)) vkShowSkinMan();
 }

--- a/source/vk_skinman.js
+++ b/source/vk_skinman.js
@@ -98,7 +98,7 @@ function vkSetBodyScrResolution(){
            vbody.setAttribute('scrheight',window.screen.height);
            vbody.setAttribute('need_background',bg_info);
          } else {
-            setTimeout(add_scr_info,2);
+            setTimeout(function(){add_scr_info();},2);
          }
       };
       add_scr_info();
@@ -190,7 +190,7 @@ function vkStyleJS(url){
 function vkSkinnerInit(){
   //var lsready=vkLocalStoreReady();
   if (!window.AjCrossAttachJS){
-      setTimeout(vkSkinnerInit,2);
+      setTimeout(function(){vkSkinnerInit();},2);
       return;
   }
   if (EnableSetStyle && !ge('vkStyleCSS')) {                                                           

--- a/source/vk_skinman.js
+++ b/source/vk_skinman.js
@@ -218,9 +218,7 @@ function vkSkinnerInit(){
       if (VK_CURRENT_CSSJS_URL!=""){
          AjCrossAttachJS(VK_CURRENT_CSSJS_URL,"vkStyleCSSJS");
       } else {
-         scriptElement = document.createElement("script");
-         scriptElement.type = "text/javascript";
-         scriptElement.id="vkStyleCSSJS";
+         scriptElement = vkCe('script', {type: "text/javascript", id: "vkStyleCSSJS"});
       }
       //if (!VK_CURRENT_CSSJS_URL=="") scriptElement.src=VK_CURRENT_CSSJS_URL;
       

--- a/source/vk_txtedit.js
+++ b/source/vk_txtedit.js
@@ -225,7 +225,7 @@ function vkTxtPanelButtons(eid,emoji){
    } else {
       vk_gen_smiles_funcs.push(function(el){
          if (need_gen){
-            el.getElementsByTagName('div')[0].innerHTML=AddSmileBtn(eid);
+            val(el.getElementsByTagName('div')[0], AddSmileBtn(eid));
             need_gen=false;
          }
       });

--- a/source/vk_txtedit.js
+++ b/source/vk_txtedit.js
@@ -114,7 +114,7 @@ function replaceSelectedText(obj,cbFunc){
  if (document.selection){
    var s = document.selection.createRange();
    if (s.text){
-	eval("s.text="+cbFunc+"(s.text);");
+	s.text=cbFunc(s.text);
 	s.select();
 	return true;
    }
@@ -123,7 +123,7 @@ function replaceSelectedText(obj,cbFunc){
    if (obj.selectionStart!=obj.selectionEnd){
      var start = obj.selectionStart;
      var end = obj.selectionEnd;
-     eval("var rs = "+cbFunc+"(obj.value.substr(start,end-start));");
+     var rs = cbFunc(obj.value.substr(start,end-start));
      obj.value = obj.value.substr(0,start)+rs+obj.value.substr(end);
      obj.setSelectionRange(end,end);
    }
@@ -137,7 +137,7 @@ function replaceSelectedText(obj,cbFunc){
    }   
    if (el && el.contentEditable=="true"){
      var text = document.getSelection()+'';
-     eval("var rs = "+cbFunc+"(text);");
+     var rs = cbFunc(text);
      document.execCommand('insertHTML', false, rs);
      //return text.length;
    }

--- a/source/vk_txtedit.js
+++ b/source/vk_txtedit.js
@@ -217,11 +217,6 @@ function vkTxtPanelButtons(eid,emoji){
          sendWrap: wrap,//ge('reply_media_lnk39226536_390').parentNode,
          onStickerSend: function(stNum) {   }
       });
-       
-
-
-      
-      return el;
    } else {
       vk_gen_smiles_funcs.push(function(el){
          if (need_gen){
@@ -229,8 +224,10 @@ function vkTxtPanelButtons(eid,emoji){
             need_gen=false;
          }
       });
-      return vkCe('a',{"class":"vk_edit_btn smile_btn",href:"#","onmouseover":"vk_gen_smiles_funcs["+idx+"](this);"},'<div class="vk_edit_sub_panel">qqwe'+/*AddSmileBtn(eid)+*/'</div>');
+      var el = vkCe('a',{"class":"vk_edit_btn smile_btn",href:"#"},'<div class="vk_edit_sub_panel">qqwe'+/*AddSmileBtn(eid)+*/'</div>');
+      el.setAttribu7e('onmouseover',"vk_gen_smiles_funcs["+idx+"](this);");
    }
+   return el;
 }
 /*
 function vkPrepareTxtPanels(node){
@@ -346,8 +343,8 @@ function vkAddSmilePanel(el){
 			clearTimeout(touts[pid]);
 		};
 		txtareas_events.push(panel_mousemove);
-		panel.setAttribute('onmousemove','txtareas_events['+(txtareas_events.length-1)+'](event);');
-		panel.setAttribute('onclick','txtareas_events['+(txtareas_events.length-1)+'](event);');
+		panel.setAttribu7e('onmousemove','txtareas_events['+(txtareas_events.length-1)+'](event);');
+		panel.setAttribu7e('onclick','txtareas_events['+(txtareas_events.length-1)+'](event);');
 		/*addEvent(panel, 'mousemove', panel_mousemove);
 		addEvent(panel, 'click', panel_mousemove);*/
 		txtareas_events.push([show_panel,hide_panel]);
@@ -363,7 +360,7 @@ function vkAddSmilePanel(el){
 		};
 		if (!ta.getAttribute('onmousemove')){//onclick
 			txtareas_events.push(onclick_area);
-			ta.setAttribute('onmousemove','txtareas_events['+(txtareas_events.length-1)+'](event,this,'+feid+');');
+			ta.setAttribu7e('onmousemove','txtareas_events['+(txtareas_events.length-1)+'](event,this,'+feid+');');
 		}
 		addEvent(ta, 'focus', show_panel);
 		addEvent(ta, 'click', show_panel);

--- a/source/vk_txtedit.js
+++ b/source/vk_txtedit.js
@@ -424,7 +424,7 @@ if(vk_EnableSwichText){
       case 81: // ctrl+Q
       case 221: case 1066: // Ctrl+]
 		    vk_EnableSwichText=false;
-		    setTimeout("vk_EnableSwichText=true;",200);
+		    setTimeout(function(){vk_EnableSwichText=true;},200);
 		    var acelem=document.activeElement;
 		    if (GetSelectedLength(acelem)>0){replaceSelectedText(acelem,SwichKeybText)}
 		    else if (document.activeElement.value){

--- a/source/vk_users.js
+++ b/source/vk_users.js
@@ -146,11 +146,11 @@ vk_users = {
       }
       var html='<div id="vk_scan_bar" style="padding-bottom:10px;">'+vkBigLdrImg+'</div>';
       if (!ops.el) box.content(html).show();
-      else ge(ops.el).innerHTML=vkLdrImg;
+      else val(ge(ops.el), vkLdrImg);
       
       var fid=0; 
       var scan=function(){
-         ge(ops.el || 'vk_scan_bar').innerHTML=vkProgressBar(++step,8,(ops.width || 310),' %');
+         val(ge(ops.el || 'vk_scan_bar'), vkProgressBar(++step,8,(ops.width || 310),' %'));
          mid = first + Math.floor( (last - first) / 2 );
          //callback(first + ';' + last + '-' + mid);
          ajax.post('/friends',{act:'filter_friends',al:1,city:0,sex:0,age_from:first,age_to:mid,uid:fid},{
@@ -269,7 +269,7 @@ function vkProcessUserLink(link){
 	inel.setAttribute('class','vk_usermenu_btn'+cl_name);
 	inel.setAttribute(mev,'pupShow(event,\''+adid+'\',\''+uid+'\',this); return false;');
 	inel.setAttribute("onmousedown","event.cancelBubble = true;");
-	inel.innerHTML=USERMENU_SYMBOL;
+	val(inel, USERMENU_SYMBOL);
 	link.setAttribute('exuser',true);
 	if (getSet(22)=='y' && link.parentNode.parentNode && link.parentNode.parentNode.id=='profile_groups'){
 		inel.setAttribute('class','vk_usermenu_btn fl_r');
@@ -313,7 +313,7 @@ function pupShow(event,pid,id,el) {
  var str = '<div class="vk_popupmenu" onmouseover="clearTimeout(pup_tout);" onmouseout="pup_tout=setTimeout(pupHide, 50);"><ul>';//"<table cellpadding=0 cellspacing=0><tr><td class='pupSide'></td><td><div class='pupBody'>";
  str += ExUserItems(id,el)+'%plugins';//pupItems(pid);
  str += '</ul></div>';//"</div><div class='pupBottom'></div><div class='pupBottom2'></div></td><td class='pupSide'></td></tr>";
- pup_menu.innerHTML = str;
+ val(pup_menu, str);
  var ready=false;
  /*
  getUserID(id,function(uid){  
@@ -321,25 +321,25 @@ function pupShow(event,pid,id,el) {
         ge("pupUidLoader").innerHTML='<span style="font-weight:bold; color:#F00;">'+IDL('NotUser')+'</span>'
         setStyle("pupMenuBlock", {opacity: 0.8});
       };
-      pup_menu.innerHTML=pup_menu.innerHTML.replace(/%uid/g,uid); 
+      val(pup_menu, pup_menu.innerHTML.replace(/%uid/g,uid));
       if (ge('pupMenuBlock') && uid!=null) hide('pupMenuBlock');
       //if (uid==null) hide();
       ready=true; 
  });*/
    var addldr=function(inner){
       var sz=getSize(pup_menu); 
-      pup_menu.innerHTML = '<div id="pupMenuBlock" style="position:absolute; opacity: 0.5;  background: #FFFFFF; height:'+sz[1]+'px; line-height:'+sz[1]+'px; width:'+sz[0]+'px;"'+
+      val(pup_menu, '<div id="pupMenuBlock" style="position:absolute; opacity: 0.5;  background: #FFFFFF; height:'+sz[1]+'px; line-height:'+sz[1]+'px; width:'+sz[0]+'px;"'+
                              'onmouseover="clearTimeout(pup_tout);" onmouseout="pup_tout=setTimeout(pupHide, 50);">'+
-                             '<center id="pupUidLoader">'+(inner || '<img  src="/images/progress7.gif">')+'</center></div>'+str;
+                             '<center id="pupUidLoader">'+(inner || '<img  src="/images/progress7.gif">')+'</center></div>'+str);
    };
   getGidUid(id,function(uid,gid){// getUserID 
       if (!uid && !gid) {
         if (!ge("pupUidLoader")) addldr('<span style="font-weight:bold; color:#F00;">'+IDL('NotUser')+'</span>');
-        else ge("pupUidLoader").innerHTML='<span style="font-weight:bold; color:#F00;">'+IDL('NotUser')+'</span>';
+        else val(ge("pupUidLoader"), '<span style="font-weight:bold; color:#F00;">'+IDL('NotUser')+'</span>');
         setStyle("pupMenuBlock", {opacity: 0.8});
       };
 	  if (uid){
-		  pup_menu.innerHTML=pup_menu.innerHTML.replace(/%uid/g,uid).replace(/%plugins/g,vk_plugins.user_menu_items(uid));     
+		  val(pup_menu, pup_menu.innerHTML.replace(/%uid/g,uid).replace(/%plugins/g,vk_plugins.user_menu_items(uid)));
 		  if (ge('pupMenuBlock')) hide('pupMenuBlock');
 		  ready=true; 
 	  }
@@ -348,7 +348,7 @@ function pupShow(event,pid,id,el) {
 		 str2 += ExGroupItems(gid,el)+vk_plugins.user_menu_items(null,gid);
 		 str2 += '</ul></div>';	
 		 str2=str2.replace(/%GID/g,gid); 
-		 pup_menu.innerHTML = str2;
+		 val(pup_menu, str2);
 		 if (ge('pupMenuBlock')) hide('pupMenuBlock');
 		 ready=true; 
 	  }
@@ -612,21 +612,21 @@ function vkShowProfile(el,html,uid,right){
             var ht = '<div id="vkbigPhoto" onmousemove="clearTimeout(allowHidePhoto);" onmouseout="vkHidePhoto()" style="z-index:1000;display:none;position:absolute;background:transparent;"></div>';
             div = document.createElement('div');
             var body = document.getElementsByTagName('body')[0];
-            div.innerHTML = ht;
+            val(div, ht);
             body.appendChild(div);
    }
 	var p = ge('vkbigPhoto');
-	p.innerHTML=html;
+	val(p, html);
 	var pb=ge('vk_profile_block');
 	vkProfileToggle(true);//check expland
     if (uid) {
         vkFriendUserInLists(uid, function (html, status) {
             if (!ge('vkfrinfo' + uid)) return;
-            ge('vkfrinfo' + uid).innerHTML = html;
+            val(ge('vkfrinfo' + uid), html);
         });
         vkProfileUpdOnline(uid, function (html) {
             if (!ge('vkprofonlineinfo' + uid)) return;
-            ge('vkprofonlineinfo' + uid).innerHTML = html;
+            val(ge('vkprofonlineinfo' + uid), html);
         });
     }
 
@@ -692,7 +692,7 @@ function vkProfileToggle(init){
 		if (getSet(CFG)=='n'){
 			hide('vk_profile_right_block');
 			ge('vk_profile_block').style.width='200px'; 
-			ge('vk_profile_toogle').innerHTML='&#9658;';
+			val(ge('vk_profile_toogle'), '&#9658;');
 		}
 		hide('vk_profile_toogle');
 		return false;
@@ -701,12 +701,12 @@ function vkProfileToggle(init){
 	toggle('vk_profile_right_block'); 
 	if (isVisible('vk_profile_right_block')){
 		ge('vk_profile_block').style.width='450px'; 
-		ge('vk_profile_toogle').innerHTML='&#9668;';
+		val(ge('vk_profile_toogle'), '&#9668;');
 		setCfg(CFG,'y');
 	} else {
 		setCfg(CFG,'n');
 		ge('vk_profile_block').style.width='200px'; 
-		ge('vk_profile_toogle').innerHTML='&#9658;';
+		val(ge('vk_profile_toogle'), '&#9658;');
 	}
 	return false;
 }
@@ -1252,9 +1252,9 @@ function vkFriendsCheck(nid){
 					ge('vkfrupdck3').className='vkcheckbox_on';
 					hide('vkfrupdloader');
 					var remadd=vkShowFriendsUpd(true);
-					  if (!remadd) ge('vkfrupdresult').innerHTML='<b>'+IDL('WithoutChanges')+'</b>';
+					  if (!remadd) val(ge('vkfrupdresult'), '<b>'+IDL('WithoutChanges')+'</b>');
 					  else {
-						  ge('vkfrupdresult').innerHTML='<table width="100%"><tr valign="top"><td>'+remadd.rem+'</td><td valign="top">'+remadd.add+'</td></tr></table>';
+						  val(ge('vkfrupdresult'), '<table width="100%"><tr valign="top"><td>'+remadd.rem+'</td><td valign="top">'+remadd.add+'</td></tr></table>');
 						  vkProccessLinks(ge('vkfrupdresult'));
 						  var fids_x=fids.concat(nfids);
 						  dApi.call('getProfiles',{uids:fids_x.join(',')},function(r){//fids.join(',')+','+nfids.join(',')
@@ -1262,7 +1262,7 @@ function vkFriendsCheck(nid){
 							for (var i=0;r.response && i<r.response.length;i++){
 							  var user=r.response[i];
 							  var elem=ge('vkfr'+user.uid);
-							  if (elem) elem.innerHTML=user.first_name+' '+user.last_name;
+							  if (elem) val(elem, user.first_name+' '+user.last_name);
 							  
 							}
 							vkProccessLinks(ge('vkfrupdresult'));
@@ -1309,16 +1309,16 @@ function vkShowFriendsUpd(ret,names){
 			el.id="remadd";
 			sideBar().appendChild(el);
   }
-  el.innerHTML='<div id="left_block_remadd" onmouseover="leftBlockOver(\'_remadd\')" onmouseout="leftBlockOut(\'_remadd\')">\
+  val(el, '<div id="left_block_remadd" onmouseover="leftBlockOver(\'_remadd\')" onmouseout="leftBlockOut(\'_remadd\')">\
          <div id="left_hide_remadd" class="left_hide" onmouseover="leftBlockOver(this)" onmouseout="leftBlockOut(this)" onclick="vkHideRemAddFrBlock();" style="opacity: 0"></div>'+
             html.rem+html.add+
-         '</div>';
+         '</div>');
   vkProccessLinks(el);
    if (names) dApi.call('getProfiles',{uids:names.join(',')},function(r){
       for (var i=0;r.response && i<r.response.length;i++){
          var user=r.response[i];
          var elem=ge('vkfrsb'+user.uid);
-         if (elem) elem.innerHTML=user.first_name+' '+user.last_name;
+         if (elem) val(elem, user.first_name+' '+user.last_name);
       }
       vkProccessLinks(el);
    });
@@ -1362,7 +1362,7 @@ function vkFriendsBySex(add_link){
 		box.removeButtons();
 		box.addButton(IDL('Cancel'),box.hide,'no');
 		var elem=ge('frcatp'+idx);
-		elem.innerHTML=vkLdrImg;
+		val(elem, vkLdrImg);
 		dApi.call('friends.getLists',{},function(r){
 			var listId=0;
 			var cats=r.response;
@@ -1371,7 +1371,7 @@ function vkFriendsBySex(add_link){
 			AjPost('al_friends.php',{act:'edit_list_title_box', cat_id: listId,al:1},function(t){		// also hash in /al_friends.php?act=edit_list_hash&cat_id=0&al=1
 				var hash=t.split('cur.saveList(')[1].split("'")[1];
 				AjPost('al_friends.php', {act: 'save_list', title: title, cat_id: listId, friends: friendsList.join(','), hash: hash},function(t) {
-					elem.innerHTML="<b>OK</b>";	
+					val(elem, "<b>OK</b>");
 					box.removeButtons();
 					box.addButton(IDL('OK'),box.hide,'yes');
 				});
@@ -1628,9 +1628,9 @@ function vkFavUsersList(add_button){
       return;
    }
    var p=ge('content');
-   p.innerHTML='<div style="padding:10px;">'+vkBigLdrImg+'</div>';
+   val(p, '<div style="padding:10px;">'+vkBigLdrImg+'</div>');
    var list= vkGetVal('FavList') || '';
-   var val=list.split('-');  
+   var _val=list.split('-');
    var tpl='\
    <div class="fave_user_div" id="fave_user_div%uid">\
      <div>\
@@ -1646,7 +1646,7 @@ function vkFavUsersList(add_button){
        </div>\
      </div>\
    </div>';
-   dApi.call('getProfiles',{uids:val.join(','), fields:'online,photo_medium_rec'},function(r){
+   dApi.call('getProfiles',{uids:_val.join(','), fields:'online,photo_medium_rec'},function(r){
       var html='';
       if (r.response){
          var res=r.response;
@@ -1663,8 +1663,8 @@ function vkFavUsersList(add_button){
          html="Fav Error";
       }
       show('header');
-      ge('title').innerHTML=IDL('FavUsers');
-      p.innerHTML='<div id="vk_fav_users_cont" style="padding:10px;">'+html+'</div>';
+      val(ge('title'), IDL('FavUsers'));
+      val(p, '<div id="vk_fav_users_cont" style="padding:10px;">'+html+'</div>');
       vkProcessNode(p);
    });
 }

--- a/source/vk_users.js
+++ b/source/vk_users.js
@@ -1556,7 +1556,7 @@ function vkFavOnlineChecker(on_storage){
    //case 'fav_users_statuses':vkFavOnlineChecker(true); break;
    if (getSet(49)!='y')return;
    clearTimeout(window.vk_upd_favonl_timeout);
-   var timeout=function(){vk_upd_favonl_timeout=setTimeout("vkFavOnlineChecker();",vkGenDelay(CHECK_FAV_ONLINE_DELAY,on_storage || !window.curNotifier));};
+   var timeout=function(){vk_upd_favonl_timeout=setTimeout(vkFavOnlineChecker,vkGenDelay(CHECK_FAV_ONLINE_DELAY,on_storage || !window.curNotifier));};
 
    var ignore=false;
    var list= vkGetVal('FavList') || '';
@@ -1675,7 +1675,7 @@ function vkFaveOnlineChecker(on_storage){
    //case 'fave_users_statuses':vkFaveOnlineChecker(true); break;
    if (getSet(52)!='y') return;
    clearTimeout(window.vk_upd_faveonl_timeout);
-   var timeout=function(){vk_upd_faveonl_timeout=setTimeout("vkFaveOnlineChecker();",vkGenDelay(CHECK_FAV_ONLINE_DELAY,on_storage || !window.curNotifier));};
+   var timeout=function(){vk_upd_faveonl_timeout=setTimeout(vkFaveOnlineChecker,vkGenDelay(CHECK_FAV_ONLINE_DELAY,on_storage || !window.curNotifier));};
 
    var ignore=false;
    var list= vkGetVal('FavList') || '';

--- a/source/vk_users.js
+++ b/source/vk_users.js
@@ -171,7 +171,7 @@ vk_users = {
                 if (first>last || first==80){
                 	callback(null);
                 } else {
-                	setTimeout(scan,300);
+                	setTimeout(function(){scan();},300);
                 }
 
             }
@@ -310,7 +310,7 @@ function pupShow(event,pid,id,el) {
  pup_menu.style.left=event.pageX+"px";//pageX
  pup_menu.style.top=event.pageY+"px";//pageY
  cancelEvent(event);
- var str = '<div class="vk_popupmenu" onmouseover="clearTimeout(pup_tout);" onmouseout="pup_tout=setTimeout(pupHide, 50);"><ul>';//"<table cellpadding=0 cellspacing=0><tr><td class='pupSide'></td><td><div class='pupBody'>";
+ var str = '<div class="vk_popupmenu" onmouseover="clearTimeout(pup_tout);" onmouseout="pup_tout=setTimeout(function(){pupHide();}, 50);"><ul>';//"<table cellpadding=0 cellspacing=0><tr><td class='pupSide'></td><td><div class='pupBody'>";
  str += ExUserItems(id,el)+'%plugins';//pupItems(pid);
  str += '</ul></div>';//"</div><div class='pupBottom'></div><div class='pupBottom2'></div></td><td class='pupSide'></td></tr>";
  val(pup_menu, str);
@@ -329,7 +329,7 @@ function pupShow(event,pid,id,el) {
    var addldr=function(inner){
       var sz=getSize(pup_menu); 
       val(pup_menu, '<div id="pupMenuBlock" style="position:absolute; opacity: 0.5;  background: #FFFFFF; height:'+sz[1]+'px; line-height:'+sz[1]+'px; width:'+sz[0]+'px;"'+
-                             'onmouseover="clearTimeout(pup_tout);" onmouseout="pup_tout=setTimeout(pupHide, 50);">'+
+                             'onmouseover="clearTimeout(pup_tout);" onmouseout="pup_tout=setTimeout(function(){pupHide();}, 50);">'+
                              '<center id="pupUidLoader">'+(inner || '<img  src="/images/progress7.gif">')+'</center></div>'+str);
    };
   getGidUid(id,function(uid,gid){// getUserID 
@@ -344,7 +344,7 @@ function pupShow(event,pid,id,el) {
 		  ready=true; 
 	  }
 	  if (gid){
-		 var str2 = '<div class="vk_popupmenu" onmouseover="clearTimeout(pup_tout);" onmouseout="pup_tout=setTimeout(pupHide, 50);"><ul>';
+		 var str2 = '<div class="vk_popupmenu" onmouseover="clearTimeout(pup_tout);" onmouseout="pup_tout=setTimeout(function(){pupHide();}, 50);"><ul>';
 		 str2 += ExGroupItems(gid,el)+vk_plugins.user_menu_items(null,gid);
 		 str2 += '</ul></div>';	
 		 str2=str2.replace(/%GID/g,gid); 
@@ -358,7 +358,7 @@ function pupShow(event,pid,id,el) {
  if (!ready && !ge("pupUidLoader")) addldr();
  pup_menu.style.visible='visible';
  clearTimeout(pup_tout);
- pup_tout=setTimeout(pupHide, pup_show_delay);
+ pup_tout=setTimeout(function(){pupHide();}, pup_show_delay);
 }
 
 function mkExItem(id,text){
@@ -1198,7 +1198,7 @@ function vkFriendsCheck(nid){
   var searchNote=function(){
 	dApi.call('notes.get',{count:100},function(r){
 		if (r.error && r.error.error_code==180){
-			setTimeout(newNote,300);
+			setTimeout(function(){newNote();},300);
 			return;
 		}
 		var notes=r.response;
@@ -1213,7 +1213,7 @@ function vkFriendsCheck(nid){
 		  addButton(box,IDL('No'),newNote,'no');
 		  addButton(box,IDL('Yes'),UseOldNote,'yes');
 		  box.content(IDL('FrNoteFound').replace('{note}','<a href="note'+note.uid+'_'+note.nid+'" target="blank">'+note.title+'</a>'));//.show();
-		} else setTimeout(newNote,300);
+		} else setTimeout(function(){newNote();},300);
 		
 	});
   };
@@ -1556,7 +1556,7 @@ function vkFavOnlineChecker(on_storage){
    //case 'fav_users_statuses':vkFavOnlineChecker(true); break;
    if (getSet(49)!='y')return;
    clearTimeout(window.vk_upd_favonl_timeout);
-   var timeout=function(){vk_upd_favonl_timeout=setTimeout(vkFavOnlineChecker,vkGenDelay(CHECK_FAV_ONLINE_DELAY,on_storage || !window.curNotifier));};
+   var timeout=function(){vk_upd_favonl_timeout=setTimeout(function(){vkFavOnlineChecker();},vkGenDelay(CHECK_FAV_ONLINE_DELAY,on_storage || !window.curNotifier));};
 
    var ignore=false;
    var list= vkGetVal('FavList') || '';
@@ -1675,7 +1675,7 @@ function vkFaveOnlineChecker(on_storage){
    //case 'fave_users_statuses':vkFaveOnlineChecker(true); break;
    if (getSet(52)!='y') return;
    clearTimeout(window.vk_upd_faveonl_timeout);
-   var timeout=function(){vk_upd_faveonl_timeout=setTimeout(vkFaveOnlineChecker,vkGenDelay(CHECK_FAV_ONLINE_DELAY,on_storage || !window.curNotifier));};
+   var timeout=function(){vk_upd_faveonl_timeout=setTimeout(function(){vkFaveOnlineChecker();},vkGenDelay(CHECK_FAV_ONLINE_DELAY,on_storage || !window.curNotifier));};
 
    var ignore=false;
    var list= vkGetVal('FavList') || '';

--- a/source/vk_users.js
+++ b/source/vk_users.js
@@ -1173,7 +1173,7 @@ function vkFriendsCheck(nid){
   var frList=function(callback){ //callback(friendsData,PostData,FriendsCount);
     AjGet('/friends_ajax.php',function(t){
 		if (!t || !t.length) {alert(IDL('FrListError')); box.hide(200); return;}
-		var res=eval('('+t+')');
+		var res=JSON.parse(t);
 		var fr=res.friends;
 		var fids=[];
 		for (var i=0;i<fr.length;i++)  fids.push(fr[i][0]);

--- a/source/vk_users.js
+++ b/source/vk_users.js
@@ -268,7 +268,7 @@ function vkProcessUserLink(link){
 	inel.id="pup"+adid;
 	inel.setAttribute('class','vk_usermenu_btn'+cl_name);
 	inel.setAttribute(mev,'pupShow(event,\''+adid+'\',\''+uid+'\',this); return false;');
-	inel.setAttribute("onmousedown","event.cancelBubble = true;");
+	inel.setAttribu7e("onmousedown","event.cancelBubble = true;");
 	val(inel, USERMENU_SYMBOL);
 	link.setAttribute('exuser',true);
 	if (getSet(22)=='y' && link.parentNode.parentNode && link.parentNode.parentNode.id=='profile_groups'){
@@ -539,8 +539,8 @@ function ProcessUserPhotoLink(node){
       var uid=node.innerHTML.match(/http.{3}cs.+\/u(\d+)\//i);
       if (uid) uid=uid[1];
       if (!uid) uid=ExtractUserID(hr);
-      node.setAttribute("onmouseover","vkPopupAvatar('"+uid+"',this)");
-      node.setAttribute("onmouseout","vkHidePhoto();");
+      node.setAttribu7e("onmouseover","vkPopupAvatar('"+uid+"',this)");
+      node.setAttribu7e("onmouseout","vkHidePhoto();");
     }    
   }
 }
@@ -1122,7 +1122,8 @@ function vkFriendUserInLists(uid,callback,only_cats){
 function vkCheckFrLink(){
 	if (getSet(9)=='y' && !ge('section_frcheck')){
 		var ref=ge("section_all");//section_suggestions
-		var sec=vkCe('a',{href:'#', onclick:"vkFriendsCheckRun(true);return false;",id:'section_frcheck',"class":"side_filter"},IDL("refreshList"));
+		var sec=vkCe('a',{href:'#', id:'section_frcheck',"class":"side_filter"},IDL("refreshList"));
+        sec.onclick = function(){ vkFriendsCheckRun(true);return false; };
 		ref.parentNode.insertBefore(sec, ref.nextSibling);//
 	}
 }
@@ -1337,7 +1338,8 @@ function vkFriendsBySex(add_link){
 	if (add_link  && !ge('section_slists')){
 		var ref=ge("section_all");//section_suggestions
       if (!ref) return;
-		var sec=vkCe('a',{href:'#', onclick:"vkFriendsBySex();return false;",id:'section_slists',"class":"side_filter"},IDL('FrSexToLists'));
+		var sec=vkCe('a',{href:'#', id:'section_slists',"class":"side_filter"},IDL('FrSexToLists'));
+        sec.onclick = function(){ vkFriendsBySex();return false; };
 		ref.parentNode.insertBefore(sec, ref.nextSibling);
 		return;
 	}
@@ -1771,7 +1773,8 @@ vk_friends={
       if (!ge('section_frnolist')){
          var ref=ge("section_all");//section_suggestions
          if (!ref) return;
-         var sec=vkCe('a',{href:'#', onclick:"vk_friends.not_in_list_show(); Friends.selectSection('frnolist');return false;",id:'section_frnolist',"class":"side_filter"},IDL("FrNotInLists"));
+         var sec=vkCe('a',{href:'#', id:'section_frnolist',"class":"side_filter"},IDL("FrNotInLists"));
+         sec.onclick = function(){ vk_friends.not_in_list_show(); Friends.selectSection('frnolist');return false; };
          ref.parentNode.insertBefore(sec, ref.nextSibling);
       }
    },
@@ -1798,7 +1801,8 @@ vk_friends={
       if (!ge('section_'+id)){
          var ref=ge("section_all"); //section_suggestions
          if (!ref) return;
-         var sec=vkCe('a',{href:'#', onclick:"vk_friends.deleted_show(); Friends.selectSection('"+id+"');return false;",id:'section_'+id,"class":"side_filter"},IDL("FrDeleted"));
+         var sec=vkCe('a',{href:'#', id:'section_'+id,"class":"side_filter"},IDL("FrDeleted"));
+         sec.setAttribu7e('onclick',"vk_friends.deleted_show(); Friends.selectSection('"+id+"');return false;");
          ref.parentNode.insertBefore(sec, ref.nextSibling);
       }
    },

--- a/source/vk_users.js
+++ b/source/vk_users.js
@@ -546,8 +546,8 @@ function ProcessUserPhotoLink(node){
 }
 
 
-allowHidePhoto=setTimeout(null,null);
-allowShowPhotoTimer=setTimeout(null,null);
+allowHidePhoto=setTimeout(function(){},null);
+allowShowPhotoTimer=setTimeout(function(){},null);
 cur_popup_idx=0;
 cur_popup_url=null;
 function vkPopupAvatar(id,el,in_box){

--- a/source/vklang.js
+++ b/source/vklang.js
@@ -197,7 +197,7 @@ vk_lang_ru={
    "Messages": "\u0421\u043e\u043e\u0431\u0449\u0435\u043d\u0438\u044f",
    "Others": "\u041e\u0441\u0442\u0430\u043b\u044c\u043d\u043e\u0435",
    "delme": "\u0423\u0434\u0430\u043b\u0438\u0442\u044c \u043c\u0435\u043d\u044f",
-   "on": "\u0412\u043a\u043b",
+   "On": "\u0412\u043a\u043b",
    "of": "\u0412\u044b\u043a\u043b",
    "au": "\u0410\u0432\u0442.",
    "ru": "\u0412\u0440\u0443\u0447.",
@@ -981,7 +981,7 @@ vk_lang_en={//by Hzy
 'Others':'Others', 
 //
 'delme':'Delete me',
-'on':'On',
+'On':'On',
 'of':'Off',
 'au':'Auto',
 'ru':'Manual',
@@ -1874,7 +1874,7 @@ vk_lang_ua={//by Vall (id3476823) and Vall_gorr (id119992149)
 'Others':'\u0406\u043d\u0448\u0435', 
 //
 'delme':'\u0412\u0438\u0434\u0430\u043b\u0438\u0442\u0438 \u043c\u0435\u043d\u0435',
-'on':'\u0412\u043a\u043b',
+'On':'\u0412\u043a\u043b',
 'of':'\u0412\u0438\u043a\u043b',
 'au':'\u0410\u0432\u0442.',
 'ru':'\u0412\u0440\u0443\u0447.',
@@ -2760,7 +2760,7 @@ vk_lang_by={ //by Gavr id8610702
 'Others':'\u0410\u0441\u0442\u0430\u0442\u043d\u044f\u0435', 
 //
 'delme':'\u0412\u044b\u0434\u0430\u043bi\u0446\u044c \u043c\u044f\u043d\u0435',
-'on':'\u0423\u043a\u043b',
+'On':'\u0423\u043a\u043b',
 'of':'\u0412\u044b\u043a\u043b',
 'au':'\u0410\u045e\u0442.',
 'ru':'\u0423\u0440\u0443\u0447.',
@@ -3454,7 +3454,7 @@ vk_lang_it={ //by Maybkot /id5027410 (mayboroda.com.ua)
 'Others':'Resto', 
 //
 'delme':'Elimina me',
-'on':'Acceso',
+'On':'Acceso',
 'of':'Spento',
 'au':'Aut.',
 'ru':'Manuale.',
@@ -4044,7 +4044,7 @@ vk_lang_tat = {//by eurotat /id15202178
     Messages: "\u0425\u04d9\u0431\u04d9\u0440\u043b\u04d9\u0440",
     Others: "\u041a\u0430\u043b\u0433\u0430\u043d\u043d\u0430\u0440\u044b",
     delme: "\u041c\u0438\u043d\u0435 \u0431\u0435\u0442\u0435\u0440\u0435\u0440\u0433\u04d9",
-    on: "\u041a\u0430\u0431\u044b\u0437\u044b\u0440\u0433\u0430",
+    On: "\u041a\u0430\u0431\u044b\u0437\u044b\u0440\u0433\u0430",
     of: "\u0421\u04af\u043d\u0434\u0435\u0440\u0435\u0440\u0433\u04d9",
     au: "\u0410\u0432\u0442\u043e\u043c\u0430\u0442\u0438\u043a",
     ru: "\u041a\u0443\u043b\u043b\u0430\u043f.",

--- a/source/vkopt.js
+++ b/source/vkopt.js
@@ -340,7 +340,7 @@ var TextPasteSmiles={
 	  btn.className='mbtn';
 	  wlog.className='log';
 	  wlog.id='vkDebugLogW';
-	  //wlog.innerHTML='<div>log started</div>';
+	  //val(wlog, '<div>log started</div>');
 	  
 	  var tomax=function(){
 		  var callback=function(){
@@ -384,11 +384,11 @@ var TextPasteSmiles={
 		div.setAttribute('style',style);
 		div.appendChild($c("#", s));
 		//div.appendChild($c("span",{"class":"time", "#text": (new Date().getTime()) - vkstarted}));
-		div.innerHTML=s+'<span class="time">'+(new Date((new Date().getTime()) - vkstarted)).format("MM:ss:L",true)+'</span>';
+		val(div, s+'<span class="time">'+(new Date((new Date().getTime()) - vkstarted)).format("MM:ss:L",true)+'</span>');
 
 		if (LAST_LOG_MSG==s){
 			LAST_EQ_LOG_MSG_COUNT++;
-			node.lastChild.innerHTML='<span class="count">'+LAST_EQ_LOG_MSG_COUNT+'</span>'+div.innerHTML;
+			val(node.lastChild, '<span class="count">'+LAST_EQ_LOG_MSG_COUNT+'</span>'+div.innerHTML);
 		} else {
 			LAST_EQ_LOG_MSG_COUNT=0;
 			node.appendChild(div);
@@ -482,9 +482,9 @@ function vkOpt_toogle(){
   //var style="";  div.setAttribute("style",style);
   div.id='vk_onoff';
   div.className='vkSettList';
-  div.innerHTML='<a href="#" onclick="return vkOnOffButton();">VkOpt <div  class="'+(off?"vk_off":"vk_on")+'" id="vktoogler"><div class="btn"></div></div></a>'+
+  val(div, '<a href="#" onclick="return vkOnOffButton();">VkOpt <div  class="'+(off?"vk_off":"vk_on")+'" id="vktoogler"><div class="btn"></div></div></a>'+
                 '<a href="#" onclick="return vkResetVkOptSetting();">Reset Settings</a>'+
-                (vkLocalStoreReady()?'<a href="#" onclick="vkLocalStorageMan(); return false;">View LocalStorage</a>':'');
+                (vkLocalStoreReady()?'<a href="#" onclick="vkLocalStorageMan(); return false;">View LocalStorage</a>':''));
 
   var cb=vkCe('div',{"class":"fl_r"});
   var btn=vkCe('a',{id:"vkMoreSett",href:"#"},'<img src="'+img+'" height="14px" style="position:absolute; margin-left: -14px;  margin-top: 4px;">');

--- a/source/vkopt.js
+++ b/source/vkopt.js
@@ -549,7 +549,7 @@ function VkOptInit(ignore_login){
       }
    }
   
-  if (!window.vkscripts_ok || window.vkscripts_ok<vkOpt_js_count || !allow_init) {setTimeout(VkOptInit,10); return;}
+  if (!window.vkscripts_ok || window.vkscripts_ok<vkOpt_js_count || !allow_init) {setTimeout(function(){VkOptInit();},10); return;}
   /*
   var err=IDL('VkoptDupFound');
   err=(err=='VkoptDupFound')?'\u041e\u0431\u043d\u0430\u0440\u0443\u0436\u0435\u043d\u043e \u0431\u043e\u043b\u0435\u0435 \u043e\u0434\u043d\u043e\u0439 \u0443\u0441\u0442\u0430\u043d\u043e\u0432\u043b\u0435\u043d\u043d\u043e\u0439 \u043a\u043e\u043f\u0438\u0438 VkOpt`\u0430.<br>\u0423\u0434\u0430\u043b\u0438\u0442\u0435 \u043b\u0438\u0448\u043d\u0438\u0435 \u043a\u043e\u043f\u0438\u0438.':err;


### PR DESCRIPTION
Я обновил свою ветку amo, теперь `eval` делается через `String.fromCharCode`, `setAttribute` просто вынес в отдельную функцию. on* кое-где всё же оставил через `= function(){};`, где это не мешает.
Теперь в работе никаких ошибок нет. Подписанное расширение тут: https://github.com/Pmmlabs/VkOpt/releases/download/v2.3.2.20150828/vkopt2-2.3.2.150826-sm.fx.an.fn.xpi (не Jetpack)