### PR TITLE
Замена JSON.parse на ev41

### DIFF
--- a/source/vk_face.js
+++ b/source/vk_face.js
@@ -1440,7 +1440,7 @@ function vkGetCalendarInfo(callback,cnt){ //callback(month, year, events, holida
       }
       res=res.split(');')[0];
 		//eval(callback+'('+res+')');
-      var args=JSON.parse('['+res+']');
+      var args=ev41('['+res+']');
       callback.apply(this,args);
 	});
 }

--- a/source/vk_lib.js
+++ b/source/vk_lib.js
@@ -167,8 +167,7 @@ if (!window.JSON) JSON ={
 	},
 	parse: function (str) {
 		if (str === "") str = '""';
-		ev41("var p=" + str + ";");
-		return p;
+        return ev41('(' + str + ')');
 	}
 };
 JSON.Str=JSON.stringify;

--- a/source/vk_page.js
+++ b/source/vk_page.js
@@ -1288,7 +1288,7 @@ function vkFaveProfileBlock(is_list){
    AjGet('/fave?section=users&al=1',function(t){
       var r=t.match(/"faveUsers"\s*:\s*(\[[^\]]+\])/);
       if (r){
-         r=JSON.parse(r[1]);
+         r=ev41('('+r[1]+')');
          var onlines=[];
          for(var i=0;i<r.length;i++) if(r[i].online) onlines.push(r[i]);
          var to=3;

--- a/source/vk_users.js
+++ b/source/vk_users.js
@@ -1175,7 +1175,7 @@ function vkFriendsCheck(nid){
   var frList=function(callback){ //callback(friendsData,PostData,FriendsCount);
     AjGet('/friends_ajax.php',function(t){
 		if (!t || !t.length) {alert(IDL('FrListError')); box.hide(200); return;}
-		var res=JSON.parse(t);
+		var res=ev41('('+t+')');
 		var fr=res.friends;
 		var fids=[];
 		for (var i=0;i<fr.length;i++)  fids.push(fr[i][0]);


### PR DESCRIPTION
В функциях календаря и проверки друзей в качестве строкового представления JSON-объекта используется часть ответа от сервера, и там свойства, состоящие только из чисел, не берутся в кавычки (почему? не знаю. Разработчики безалаберные, не следуют стандарту).
Поэтому эти функции не работают. Исправлено возвращением использования `eval` (в адаптированной форме)
А также исправлена JS-реализация метода JSON.parse, чтобы она не затрагивала глобальную область.