### PR TITLE
Диалоговые окна с возможностью сворачивания

### DIFF
--- a/source/vk_lib.js
+++ b/source/vk_lib.js
@@ -2489,16 +2489,42 @@ vkLdr={
 	}
 };
 
-function vkAlertBox(title, text, callback, confirm) {// [callback] - "Yes" or "Close" button; [confirm] - "No" button
-  var aBox = new MessageBox({title: title});
-  aBox.removeButtons();
-  if (confirm) {
-   aBox.addButton(getLang('box_no'),function(){  aBox.hide(); if (isFunction(confirm)) confirm();	 }, 'no').addButton(getLang('box_yes'),function(){  aBox.hide(); if (callback) callback();	 },'yes');
+function vkAlertBox(title, text, callback, confirm, minimizable) {// [callback] - "Yes" or "Close" button; [confirm] - "No" button
+  if (minimizable) {    // вывод контента в видеоплеере, который можно сворачивать
+      var vp = vkCe('div', {id: 'video_player', style: 'overflow:auto'});
+      var box_body = vkCe('div', {'class': 'box_body'}, text);
+      vp.appendChild(box_body);
+      stManager.add(['videoview.js', 'videoview.css', 'page.js', 'page.css'], function () {
+          videoview.show(false, '0_', '', {noHistory: 1, prevLoc: nav.objLoc});
+          mvcur.mvContent.appendChild(vp);
+          hide(mvcur.mvLoader, mvcur.mvControls); // скрыть картинку с анимацией загрузки и блок для комментариев
+          if (title) {  // заголовок будет отображаться только в свернутом окне.
+              mvcur.mvData.published = 1;
+              mvcur.mvData.title = title;
+          }
+      });
+      return {
+          setOptions: function (items) {    // для совместимости с MessageBox
+              for (var i in items)
+                  if (box_body.style.setProperty) {
+                      box_body.style.setProperty(i, items[i], '');
+                  } else box_body.style[i] = items[i];
+          },
+          content: function(html) {
+              box_body.innerHTML = html;
+          }
+      };
   } else {
-    aBox.addButton(getLang('box_close'),callback?function(){aBox.hide(); callback();}:aBox.hide);
+      var aBox = new MessageBox({title: title});
+      aBox.removeButtons();
+      if (confirm) {
+       aBox.addButton(getLang('box_no'),function(){  aBox.hide(); if (isFunction(confirm)) confirm();	 }, 'no').addButton(getLang('box_yes'),function(){  aBox.hide(); if (callback) callback();	 },'yes');
+      } else {
+        aBox.addButton(getLang('box_close'),callback?function(){aBox.hide(); callback();}:aBox.hide);
+      }
+      aBox.content(text);
+      return aBox.show();
   }
-  aBox.content(text);
-  return aBox.show();
 }
 //Download with normal name by dragout link
 function vkDragOutFile(el) {

--- a/source/vk_main.js
+++ b/source/vk_main.js
@@ -439,7 +439,7 @@ function vkWikiPagesList(add_btn){
             '<a href="#" onclick="return vkGetWikiCode('+obj.pid+','+obj.group_id+');">'+IDL('Code')+'</a><span class="divider">|</span>'+
             '   <b>'+obj.title+'</b>  (creator:'+obj.creator_name+')<br>';
       });
-      var box=vkAlertBox('Wiki Pages',t);
+      var box=vkAlertBox('Wiki Pages',t,null,null,true);
       box.setOptions({width:'680px'});
    });
 }
@@ -1723,7 +1723,7 @@ function vkIMSaveHistoryBox(peer){
       <div class="button_gray"><button href="#" onclick="vkMakeMsgHistory('+peer+',true); return false;">'+IDL('SaveHistoryCfg')+'</button></div>\
       </div>\
    </div>';
-   vkAlertBox(IDL('SaveHistory'), t);
+   vkAlertBox(IDL('SaveHistory'), t, null, null, true);
 }
 
 /* NOTIFIER */

--- a/source/vk_media.js
+++ b/source/vk_media.js
@@ -841,7 +841,7 @@ var vk_photos = {
       });
    },
     albums_links: function (oid) {   // Реализация функции получения ссылок на все фотографии с группировкой по альбомам. (в виде скрипта)
-        var box = vkAlertBox(document.title, '<div id="vk_links_container1"></div><br/><div id="vk_links_container2"></div>');
+        var box = vkAlertBox(document.title, '<div id="vk_links_container1"></div><br/><div id="vk_links_container2"></div>', null, null, true);
         var Progress = function (c, f) {    // обновление прогрессбара для альбомов
             if (!f) f = 1;
             ge('vk_links_container1').innerHTML = vkProgressBar(c, f, 350);


### PR DESCRIPTION
Некоторые функции требуют продолжительного времени, когда надо сидеть и смотреть на прогрессбары. Было бы удобнее, если бы диалоговые окна можно было свернуть, чтобы выполнение задания продолжалось в фоне.
Предлагаю использовать для этого видеоплеер, где уже реализована функция сворачивания. В функции `vkAlertBox` добавлен пятый параметр, определяющий, показывать ли контент в видео плеере или как раньше, в MessageBox-е. А также новый метод отображения задействован в 3-х функциях (для пробы): список wiki-страниц, сохранение переписки и получение ссылок на все фото пользователя.
![1](https://cloud.githubusercontent.com/assets/2682026/10018747/dec0f752-6141-11e5-836b-a464e76b070f.png)
Скриншот в свернутом состоянии:
![2](https://cloud.githubusercontent.com/assets/2682026/10018748/dec12e66-6141-11e5-8ff0-d388a402ffc7.png)
Можно менять размер, перетаскивать, как видеоплеер. При клике на ссылки внутри свернутого окошка, открываются страницы, а окошко остается.
Кстати, в такое окошко можно запихнуть и некоторые вконтактовские функции, которые тоже не допускают сворачивания.