### PR TITLE
Исправление  исчезающих кнопок в группах

### DIFF
--- a/source/vk_page.js
+++ b/source/vk_page.js
@@ -1635,8 +1635,7 @@ vk_graff={
 
 function vkModGroupBlocks(){
    var el=ge('group_albums');// || ge('public_albums');
-   if (el && !ge('gr_photo_browse')){
-      el=geByClass('p_header_bottom',el)[0];
+   if (el && !ge('gr_photo_browse') && (el=geByClass('p_header_bottom',el)[0])){
       var a=vkCe('a',{id:'gr_photo_browse', href:'/photos'+cur.oid, onclick:"event.cancelBubble = true; return nav.go(this, event)"},IDL("obzor",1));
       el.appendChild(a);
       //el.innerHTML+='<a href="/photos'+cur.oid+'" onmousedown="event.cancelBubble = true;" onclick="event.cancelBubble = true; return nav.go(this, event);">[ '+IDL("obzor")+' ]</a>';


### PR DESCRIPTION
Если в администрируемой группе нет ни одного фотоальбома,  в функции `vkModGroupBlocks` случается ошибка и дальше выполнение не идёт, и кнопки просмотра wiki-страниц и др. не добавляются.