### PR TITLE
Исправление вставки картинок из буфера в ФФ

### DIFF
--- a/source/vk_media.js
+++ b/source/vk_media.js
@@ -6755,7 +6755,10 @@ if (!window.vkscripts_ok) window.vkscripts_ok=1; else window.vkscripts_ok++;
             });
       },
       onPaste: function (e) {
+         var attr = e.target.getAttribute('contenteditable');   // бекап и восстановление атрибута contenteditable
+         e.target.setAttribute('contenteditable','');           // для избежания Emoji.getRange() в emoji.js:229
          setTimeout(function () {
+            e.target.setAttribute('contenteditable',attr);
             var img = geByTag('img', e.target)[0];
             if (img) {
                var binary = atob(img.src.split('base64,')[1]);


### PR DESCRIPTION
Из-за [изменений](https://github.com/Pmmlabs/vk_mirror/commit/e9792479f12b54b751ff610f225e410151ddffec#diff-011f875d8d312e5506a7668224bf8246) Вконтакте вставка картинок из буфера перестала работать.
Исправлено в соответствии с новым кодом.