### PR TITLE
Замена ` на ' в скриптах wget

### DIFF
--- a/source/vk_media.js
+++ b/source/vk_media.js
@@ -6555,7 +6555,7 @@ vk_au_down={
             links.push(itm.url+(itm.url.indexOf('?')>0?'&/':'?/')+vkEncodeFileName(vkCleanFileName(itm.artist+" - "+itm.title))+".mp3");
 
             wget_links.push('wget "'+itm.url+'" -O "'+vkCleanFileName(winToUtf(itm.artist+" - "+itm.title))+'.mp3"');
-            wget_links_nix.push('wget "'+itm.url+'" -O "'+winToUtf(itm.artist+" - "+itm.title).replace(/"/g,'\\"')+'.mp3"');
+            wget_links_nix.push('wget "'+itm.url+'" -O "'+winToUtf(itm.artist+" - "+itm.title).replace(/"/g,'\\"').replace(/`/g,'\'')+'.mp3"');
 			
 			metalinklist.push('<file name="'+vkCleanFileName(winToUtf(itm.artist+" - "+itm.title))+'.mp3'+'">'
 								+'<resources><url type="http" preference="100">'+itm.url+'</url></resources>'
@@ -6679,7 +6679,7 @@ if (!window.vkopt_plugins) vkopt_plugins = {};
                     var el = vkCe('div', {}, arr[6]);
                     each(geByClass('audio', el), function (i, row) {
                         var url = geByTag('input', row)[0].value;
-                        var filename = vkCleanFileName(geByClass('title_wrap', row)[0].innerText) + '.mp3';
+                        var filename = vkCleanFileName(geByClass('title_wrap', row)[0].innerText).replace(/`/g,'\'') + '.mp3';
                         vkopt_plugins[PLUGIN_ID].links.push(url + '&/' + vkEncodeFileName(filename));
                         vkopt_plugins[PLUGIN_ID].wget_links.push('wget "' + url + '" -O "' + winToUtf(filename) + '"');
                     });
@@ -6702,7 +6702,7 @@ if (!window.vkopt_plugins) vkopt_plugins = {};
                         var filename = vkCleanFileName(
                             (geByClass('fl_l', row, 'span')[0] ||       // gifки
                             geByClass('page_doc_photo_hint', row)[0] || // картинки
-                            geByClass('a', row, 'span')[0]).innerText); // файлы
+                            geByClass('a', row, 'span')[0]).innerText).replace(/`/g,'\''); // файлы
                         vkopt_plugins[PLUGIN_ID].links.push(url + '&/' + vkEncodeFileName(filename));
                         vkopt_plugins[PLUGIN_ID].wget_links.push('wget "' + url + '" -O "' + winToUtf(filename) + '"');
                     });

--- a/source/vk_page.js
+++ b/source/vk_page.js
@@ -1857,7 +1857,7 @@ function vkDocsShowBox(tpl) {	// создание таблички со сылк
 			for (var i in vkDocsLinks) {
 				var item = vkDocsLinks[i];
 				links+=item.url+'&/'+vkEncodeFileName(vkCleanFileName(item.filename))+'\n';
-				wget_links+='wget "'+item.url+'" -O "'+winToUtf(item.filename).replace(/"/g,'\\"')+'"\n';
+				wget_links+='wget "'+item.url+'" -O "'+winToUtf(item.filename).replace(/"/g,'\\"').replace(/`/g,'\'')+'"\n';
 			}
 			var links_html='<textarea class="vk_docs_links_area">'+links+'</textarea>\
 					   <a download="DocumentsLinks.txt" href="data:text/plain;base64,' + base64_encode(utf8ToWindows1251(utf8_encode(links))) + '">'+vkButton(IDL('.TXT'))+'</a>\


### PR DESCRIPTION
В скриптах wget для Linux надо заменять <kbd>\`</kbd> на `'` в именах файлов.
На Windows этот символ можно оставить, он разрешается