### PR TITLE
Исправление бага в кнопках перемотки постов

### DIFF
--- a/source/vk_page.js
+++ b/source/vk_page.js
@@ -3311,7 +3311,9 @@ vk_feed={
                if (elem) {
                    while (elem && elem.getBoundingClientRect().top-topShift < -3 || elem.getBoundingClientRect().left==0)
                        elem = elem.nextElementSibling;
-                   elem = elem.previousElementSibling;         // в этом месте elem был текущим постом, а стал предыдущим
+                   do
+                       elem = elem.previousElementSibling;         // в этом месте elem был текущим постом, а стал предыдущим
+                   while (getXY(elem)[1]==0);   // для предотвращения перемотки к скрытому посту
                    if (elem) scrollToY(getXY(elem)[1]-topShift, 100);
                    window.scrollAnimation = false;
                    wall.scrollCheck(); // для подгрузки стены


### PR DESCRIPTION
Дополнение к #130 
Когда нажимаем кнопку "предыдущий", а предыдущий скрыт фильтром рекламы, страница перематывается на самый верх, потому что для скрытых элементов top будет 0.