### PR TITLE
Youtube полноэкранный режим

### DIFF
--- a/source/vk_main.js
+++ b/source/vk_main.js
@@ -761,7 +761,7 @@ function vkProcessResponse(answer,url,q){
      answer[2]=answer[2].replace(/"show_ads"\s*:\s*"?\d+"?/i,'"show_ads":0');
   }
   if (getSet(107)=='y' && url=='/al_video.php' && (q.act == 'show' || q.act == 'show_inline')) {
-      answer[1]=answer[1].replace('controls=0','controls=1');
+      answer[1]=answer[1].replace('controls=0','controls=1').replace('fs=0','fs=1').replace('<iframe','<iframe allowfullscreen="true"');
       answer[2]=answer[2].replace('if (1)','if (0)');
   }
 }


### PR DESCRIPTION
Дополнение к #223 
Оказалось, что при включенной функции "Использовать плеер Youtube для видео с Youtube" нет кнопки "полноэкранный режим". Так что возвращаем.