### PR TITLE
Исправление ссылки на сайт в быстром профиле группы

### DIFF
--- a/source/vk_users.js
+++ b/source/vk_users.js
@@ -991,7 +991,7 @@ function vkGetGroup(gid, callback, no_switch_button) {
                 [type, IDL('Type')],
                 [profile.members_count, IDL('clGu')],
                 [MakeContacts(profile.contacts), IDL('Contacts')],
-                [profile.site ? '<a href="http://'+profile.site+'" target="_blank">'+profile.site+'</a>' : '', IDL('Site')],
+                [profile.site ? '<a href="http://'+profile.site.replace(/https?:\/\//,'')+'" target="_blank">'+profile.site+'</a>' : '', IDL('Site')],
                 [profile.can_post ? IDL('Yes') : IDL('No'), IDL('AbilityToPost')]
             ];
             if (profile.deactivated) {


### PR DESCRIPTION
Если у группы сайт содержит `http://`, то ссылка во всплывающем профиле получается неправильная. Убираем протокол из ссылки.
![- 27 10 2015 - 18 42 59](https://cloud.githubusercontent.com/assets/2682026/10763398/d2f06e62-7cda-11e5-9276-11ef785cf54e.png)
