### PR TITLE
 Исправление прыгающих элементов аудио

### DIFF
--- a/source/vk_face.js
+++ b/source/vk_face.js
@@ -282,9 +282,13 @@ function vkStyles(){
          margin-bottom: 0px !important;\
          margin-top: 0px !important;\
       }\
-      .audio .play_btn_wrap, .audio .title_wrap, .duration{\
+      .audio .title_wrap, .duration{\
          padding-bottom: 2px !important;\
          padding-top:2px !important;\
+      }\
+      .audio .play_btn_wrap{\
+         padding-top: 1px !important;\
+         padding-bottom: 2px !important;\
       }\
       .audio .area {margin-bottom: 0px !important;}\
       .choose_audio_row {height:auto !important;}\
@@ -295,7 +299,9 @@ function vkStyles(){
 	var img="data:image/gif;base64,R0lGODdhEAARALMAAF99nf///+7u7pqxxv///8nW4AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAACwAAAAAEAARAAAEJpCUQaulRd5dJ/9gKI5hYJ7mh6LgGojsmJJ0PXq3JmaE4P9AICECADs=";
 	main_css+='\
 		.play_new{float:left; width: 17px !important;}\
-		.vkaudio_down{border-spacing: 0px;}\
+		.vkaudio_down{margin-top: -1px; float: left;}\
+		.play_btn_wrap{padding-right:0 !important;}\
+		.audio .title_wrap b{padding-left:6px;}\
 		.audio_table .audio td.play_btn {width: 40px !important;}\
 		.audio .down_btn { \
          background-image: url("'+img+'") !important; \

--- a/source/vk_media.js
+++ b/source/vk_media.js
@@ -6470,19 +6470,10 @@ vk_au_down={
    },
    make_d_btn:function(url,el,id,name){
        url = url.replace(/https:\/\//,'http://');
-       var table=document.createElement('table');
-       table.className="vkaudio_down";
-       var tr=document.createElement('tr');
-       table.appendChild(tr);
-       el.parentNode.appendChild(table);
        
-       var td=document.createElement('td');
-       tr.appendChild(td);  
-       td.appendChild(el); 
-       td=document.createElement('td');
-       td.setAttribute('style',"vertical-align: top;");
-       td.innerHTML='<a href="'+url+'"  download="'+name+'" title="'+name+'" onmousedown="vk_audio.prevent_play();" onclick="vk_audio.prevent_play(); return vkDownloadFile(this);" onmouseover="vkDragOutFile(this);"><div onmouseover_="vk_audio.get_size(\''+id+'\',this)" class="play_new down_btn" id="down'+id+'"></div></a>';
-       tr.appendChild(td);  
+       var td=vkCe('div', {'class':"vkaudio_down"},'<a href="'+url+'"  download="'+name+'" title="'+name+'" onmousedown="vk_audio.prevent_play();" onclick="vk_audio.prevent_play(); return vkDownloadFile(this);" onmouseover="vkDragOutFile(this);"><div onmouseover_="vk_audio.get_size(\''+id+'\',this)" class="play_new down_btn" id="down'+id+'"></div></a>');
+       var parent = geByClass('title_wrap',el.parentNode.parentNode.parentNode)[0];
+       parent.insertBefore(td, parent.firstChild);
        el.setAttribute('vk_ok','1'); 
        if (AUDIO_AUTOLOAD_BITRATE){
           setTimeout(function(){


### PR DESCRIPTION
Решение для #236
Иногда элементы строки аудиозаписи расползаются, особенно видно в Firefox при определенном масштабе, видимо относительные размеры элементов неправильно рассчитываются.

Кнопка скачивания аудиозаписи перенесена в блок с информацией, так что теперь его размеры изменяться не будут и элементы прыгать тоже не будут.


![default](https://cloud.githubusercontent.com/assets/2682026/10949880/45824682-8346-11e5-8a6f-abdd0a2f51eb.png)