### PR TITLE
Сворачивание видео с Youtube

### DIFF
--- a/source/vk_main.js
+++ b/source/vk_main.js
@@ -762,7 +762,7 @@ function vkProcessResponse(answer,url,q){
   }
   if (getSet(107)=='y' && url=='/al_video.php' && (q.act == 'show' || q.act == 'show_inline')) {
       answer[1]=answer[1].replace('controls=0','controls=1').replace('fs=0','fs=1').replace('<iframe','<iframe allowfullscreen="true"');
-      answer[2]=answer[2].replace('if (1)','if (0)');
+      answer[2]=answer[2].replace(/if \(1\)/g,'if (0)');
   }
 }
 


### PR DESCRIPTION
Исправление для #223 
При включенной опции "Использовать плеер Youtube для видео с Youtube" кнопка "свернуть" работала некорректно, из-за того, что замена кода была неглобальной.