### PR TITLE
Cкрипт python для паковки расширения для Chrome

### DIFF
--- a/builds/_chrome_pack.sh
+++ b/builds/_chrome_pack.sh
@@ -1,0 +1,2 @@
+rm vkopt_chrome.zip
+./_zip_packer.py chrome vkopt_chrome.zip


### PR DESCRIPTION
Для упаковки хромовского расширения использовать python. Кстати, размер zip файла получается меньше, чем при упаковке WinRar-ом.