### PR TITLE
Градиентный фон в youtube-плеере

### DIFF
--- a/source/vk_face.js
+++ b/source/vk_face.js
@@ -622,7 +622,10 @@ function vkStyles(){
          .search_bar:hover .vk_idattach{display:block;}\
 	";
    if (getSet(107) == 'y')
-         main_css += '#mv_external_finish { height: 89% !important; }';
+         main_css += 'div#mv_external_finish {' +
+             'height: 85%;' +
+             'background: linear-gradient(to top, transparent, rgba(0,0,0,0.9) 10%);' +
+             '}';
    main_css+=vk_menu.css;
    main_css+=vk_settings.css;   
    main_css+=vk_board.css;


### PR DESCRIPTION
Для #255 
После просмотра видео в плеере youtube нижнюю границу серого фона предлагаю сделать не резкой, а плавной (градиентом)
![default](https://cloud.githubusercontent.com/assets/2682026/12007411/50647bd2-ac14-11e5-9578-9b3745604a66.png)
