### PR TITLE
Новогоднее исправление для подписок на стены

### DIFF
--- a/source/vk_page.js
+++ b/source/vk_page.js
@@ -4558,7 +4558,7 @@ if (!window.vkopt_plugins) vkopt_plugins = {};
                     for (var i = 0; i < 12 && m == undefined; i++)
                         if (getLang('month' + (i + 1) + 'sm_of') == datetime[1])
                             m = i;
-                    y = parseInt(datetime[2]) || new Date().getFullYear();
+                    y = parseInt(datetime[2]) || new Date().getFullYear() - +(m > (new Date().getMonth()));
                     if (datetime.length < 4) H = M = 0; // если нет времени
                 }
 


### PR DESCRIPTION
Исправление для #164 
В новогоднюю ночь все посты на стенах стали прошлогодними, но в серых подписях (там, где дата) номер года не появился. Наверное, он появляется у постов старше определенного срока, а не у прошлогодних постов.
Вследствие чего все посты со всех стен вставились в начало ленты (т.к. год их публикации распознался как 2016)
Поэтому исправление: если год не указан, и месяц поста больше текущего, то от текущего года отнять один.