### PR TITLE
Модуль позволяет просматривать репосты, ссылки, форварды, в выбранном диалоге

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -1,0 +1,1 @@
+theme: jekyll-theme-midnight

--- a/source/vklang.js
+++ b/source/vklang.js
@@ -770,7 +770,16 @@ vk_lang_ru={
    ,"seRecentEmoji":"\u0411\u043b\u043e\u043a \u043d\u0435\u0434\u0430\u0432\u043d\u043e \u0438\u0441\u043f\u043e\u043b\u044c\u0437\u043e\u0432\u0430\u043d\u043d\u044b\u0445 Emoji \u0432 \u0434\u0438\u0430\u043b\u043e\u0433\u0430\u0445"
    ,"Skip_pl":"\u041f\u0440\u043e\u043f\u0443\u0441\u0442\u0438\u0442\u044c"
    ,"seAudioDelButtonPl":"\u041a\u043d\u043e\u043f\u043a\u0430 \u00ab\u041f\u0440\u043e\u043f\u0443\u0441\u0442\u0438\u0442\u044c\u00bb \u0432 \u043f\u043b\u0435\u0435\u0440\u0435 \u0438\u0437 \u0448\u0430\u043f\u043a\u0438"
-};
+   ,"LinksAndRepost": "\u0421\u0441\u044B\u043B\u043A\u0438  \u0438  \u0440\u0435\u043F\u043E\u0441\u0442\u044B"
+    ,
+    "LinksAndRepost_all": "\u0412\u0441\u0435"
+    ,
+    "LinksAndRepost_forward": "\u0424\u043E\u0440\u0432\u0430\u0440\u0434\u044B"
+    ,
+    "LinksAndRepost_link": "\u0421\u0441\u044B\u043B\u043A\u0438"
+    ,
+    "LinksAndRepost_post": "\u0420\u0435\u043F\u043E\u0441\u0442\u044B"
+   };
 
 vk_lang_en={//by Hzy
 'LangAuthor':'by Hzy',
@@ -1693,6 +1702,15 @@ vk_lang_en={//by Hzy
   ,"seRecentEmoji":"Block with recent Emoji in dialogs"
   ,"Skip_pl":"Skip"
   ,"seAudioDelButtonPl":"«Skip» button in topplayer"
+  ,"LinksAndRepost": "Links and repost"
+    ,
+    "LinksAndRepost_all": "All"
+    ,
+    "LinksAndRepost_forward": "Forward"
+    ,
+    "LinksAndRepost_link": "Link"
+    ,
+    "LinksAndRepost_post": "Post"
 };
 
 vk_lang_ua={//by Vall (id3476823) and Vall_gorr (id119992149)

--- a/source/vkopt.js
+++ b/source/vkopt.js
@@ -890,7 +890,7 @@ vkopt['settings'] =  {
 		  </div>
       */
       /*color_input:
-      <div id="vk_color_input_{vals.id}" class="vk_color_switcher clear_fix">
+       <div id="vk_color_input_{vals.id}" class="vk_color_switcher clear_fix">
 			<div class="vk_color_label">{vals.caption}</div>
 			<div class="dev_labeled">
 			  # <input type="text" onchange="vkopt.settings.set('{vals.id}', this.value); setStyle(ge('dev_colorbox{vals.id}'),{backgroundColor: '#'+this.value});" class="text dev_constructor_input" id="widget_color{vals.id}" value="{vals.curColorNoSharp}" style="width: 50px;" onkeyup="cur.soonUpdatePreview();">
@@ -2140,28 +2140,28 @@ vkopt['audio'] =  {
          padding-bottom: 5px;
          padding-top: 5px;
       }
-      .top_audio_layer .audio_row .audio_act.audio_act_rem_from_pl{
+       .top_audio_layer .audio_row .audio_act.audio_act_rem_from_pl{
          display: block;
       }
-      .top_audio_layer .audio_row .audio_act.audio_act_rem_from_pl>div{
-         height: 12px;
-         width: 14px;
-         background-image: url("data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAA4AAAAMBAMAAACgrpHpAAAAGFBMVEUAAAByk7dyk7Zyk7Zyk7Zyk7ZzlLdyk7aWV8ipAAAAB3RSTlMA7SIuBBjsKPzYuwAAAEFJREFUCNdjEC8HgkIGCF3GgAyKGJgKgOLs5Q7u5UCatby4vBQkzl5eDpZnLi8G6WNwLy93ANJMQPkisDQQwfQDAJLaEk3kz9tlAAAAAElFTkSuQmCC");
-      }
-      .top_audio_layer .audio_row.audio_skipped .audio_act.audio_act_rem_from_pl,
-      .top_audio_layer .audio_row.audio_row_playing .audio_act.audio_act_rem_from_pl,
-      .top_audio_layer .audio_row.audio_row_playing.audio_added_next.audio_skipped .audio_act.audio_act_rem_from_pl{
-         display: none;
+       .top_audio_layer .audio_row .audio_act.audio_act_rem_from_pl>div{
+       height: 12px;
+       width: 14px;
+       background-image: url("data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAA4AAAAMBAMAAACgrpHpAAAAGFBMVEUAAAByk7dyk7Zyk7Zyk7Zyk7ZzlLdyk7aWV8ipAAAAB3RSTlMA7SIuBBjsKPzYuwAAAEFJREFUCNdjEC8HgkIGCF3GgAyKGJgKgOLs5Q7u5UCatby4vBQkzl5eDpZnLi8G6WNwLy93ANJMQPkisDQQwfQDAJLaEk3kz9tlAAAAAElFTkSuQmCC");
+       }
+       .top_audio_layer .audio_row.audio_skipped .audio_act.audio_act_rem_from_pl,
+       .top_audio_layer .audio_row.audio_row_playing .audio_act.audio_act_rem_from_pl,
+       .top_audio_layer .audio_row.audio_row_playing.audio_added_next.audio_skipped .audio_act.audio_act_rem_from_pl{
+       display: none;
       }
       .audio_row.audio_skipped .audio_info{
          opacity: 0.5;
-      }
-      .audio_row.audio_added_next.audio_skipped .audio_info{
-         opacity:1
-      }
-      .audio_row.audio_added_next.audio_skipped .audio_act.audio_act_rem_from_pl{
-         display:block;
-      }
+       }
+       .audio_row.audio_added_next.audio_skipped .audio_info{
+       opacity:1
+       }
+       .audio_row.audio_added_next.audio_skipped .audio_act.audio_act_rem_from_pl{
+       display:block;
+       }
        */
       });
       return codes.dl;
@@ -2210,7 +2210,7 @@ vkopt['audio'] =  {
       <a class="audio_act vk_audio_acts" data-aid="{vals.id}" onmouseover="vkopt.audio.acts.menu(this);" onclick="cancelEvent(event)"><div></div></a>
       */
       /*del_button:
-      <a class="audio_act audio_act_rem_from_pl" id="vk_delete_pl" onmouseover="showTooltip(this,{text:IDL('Skip_pl'),black:1,shift:[7,5,0],needLeft:true})" onclick="vkopt.audio.delete_from_pl_act(event,'{vals.id}')"><div></div></a>
+       <a class="audio_act audio_act_rem_from_pl" id="vk_delete_pl" onmouseover="showTooltip(this,{text:IDL('Skip_pl'),black:1,shift:[7,5,0],needLeft:true})" onclick="vkopt.audio.delete_from_pl_act(event,'{vals.id}')"><div></div></a>
       */
       /*size_info:
       <small class="fl_l vk_audio_size_info_wrap" id="vk_audio_size_info_{vals.id}">
@@ -2480,7 +2480,8 @@ vkopt['audio'] =  {
          var info = null;
          try {
             info = JSON.parse(row.dataset["audio"]);
-         } catch(e) {}
+         } catch (e) {
+         }
          if (!acts || !info) continue;
          var info_obj = AudioUtils.asObject(info);
          if (info_obj.url==""){                    // собираем очередь из аудио, которым требуется подгрузка инфы
@@ -2771,14 +2772,14 @@ vkopt['audio'] =  {
    },
    delete_from_pl_act: function (ev, id) {
        var row = gpeByClass("audio_row", ev.target);
-       if (hasClass(row, 'audio_added_next') || !hasClass(row, 'audio_skipped')){ // наличие класса .audio_added_next разрешает убрать трек из очереди
-          // при добавлении трека после исключения обратно в очередь следующим,
-          // нужно чтоб класс .audio_added_next перекрывал визуальто стиль от .audio_skipped
-          // т.е тут роль костыля будет играть класс .audio_added_next.audio_skipped{opacity:1}
-          // вместо того, чтоб делать инъекцию в setNext для удаления класса audio_skipped
-          getAudioPlayer().getCurrentPlaylist().removeAudio(id);
-          addClass(row, "audio_skipped");
-          removeClass(row, "audio_added_next"); // чтоб трек можно было вернуть в очередь
+       if (hasClass(row, 'audio_added_next') || !hasClass(row, 'audio_skipped')) { // наличие класса .audio_added_next разрешает убрать трек из очереди
+           // при добавлении трека после исключения обратно в очередь следующим,
+           // нужно чтоб класс .audio_added_next перекрывал визуальто стиль от .audio_skipped
+           // т.е тут роль костыля будет играть класс .audio_added_next.audio_skipped{opacity:1}
+           // вместо того, чтоб делать инъекцию в setNext для удаления класса audio_skipped
+           getAudioPlayer().getCurrentPlaylist().removeAudio(id);
+           addClass(row, "audio_skipped");
+           removeClass(row, "audio_added_next"); // чтоб трек можно было вернуть в очередь
        }
    }
 
@@ -6660,26 +6661,27 @@ vkopt['turn_blocks'] = {
 }
 
 vkopt['audio_clean_titles'] = {
-	onSettings:{
-		Media:{
-			audio_clean_titles: {
-				title: 'seAudioUntrashTitle'
-			}}
-	},
-	processNode: function (node, params) {
-		if (vkopt.settings.get('audio_clean_titles')){ // clean titles
-			var nodes=geByClass('audio_title_wrap',node);
-			for (var i=0; i<nodes.length; i++){
-				FindAndProcessTextNodes(nodes[i],function(mainNode,childItem){
-					var el = mainNode.childNodes[childItem];
-					if (el.nodeValue && !/^[\u2013\s]+$/.test(el.nodeValue)){
-						el.nodeValue=vkopt.audio.remove_trash(el.nodeValue);
-					}
-					return childItem;
-				});
-			}
-		}
-	}
+    onSettings: {
+        Media: {
+            audio_clean_titles: {
+                title: 'seAudioUntrashTitle'
+            }
+        }
+    },
+    processNode: function (node, params) {
+        if (vkopt.settings.get('audio_clean_titles')) { // clean titles
+            var nodes = geByClass('audio_title_wrap', node);
+            for (var i = 0; i < nodes.length; i++) {
+                FindAndProcessTextNodes(nodes[i], function (mainNode, childItem) {
+                    var el = mainNode.childNodes[childItem];
+                    if (el.nodeValue && !/^[\u2013\s]+$/.test(el.nodeValue)) {
+                        el.nodeValue = vkopt.audio.remove_trash(el.nodeValue);
+                    }
+                    return childItem;
+                });
+            }
+        }
+    }
 }
 
 vkopt['attachments_and_link'] = {

--- a/source/vkopt.js
+++ b/source/vkopt.js
@@ -6761,7 +6761,7 @@ vkopt['attachments_and_link'] = {
                     Array.prototype.push.apply(objmess, dataItem.item.data);
                     if (objmess.length < self.COUNT_ROW && self.local.lastid != 'eof') {
                         setTimeout(function () {
-                            self.getHistoryAttr(dataItem.item.last, 0, strongId, objmess);
+                            self.getHistoryAttr(dataItem.status == 'segment' ? self.local.lastid : dataItem.item.last, 0, strongId, objmess); //в случае если это сегмент dataItem.item.last будет конец сегмента
                         });
                         break;
                     }
@@ -6875,7 +6875,7 @@ vkopt['attachments_and_link'] = {
              z-index: 900;
              border: 2px solid #f7f7f7;
              border-left: 1px solid rgba(0,0,0,.1);
-             width: 25%;
+             width: 30%;
              }
              #history_list  li {
              list-style-type: none;
@@ -7318,6 +7318,7 @@ vkopt['attachments_and_link'] = {
     getHistoryAttr: function (first, last, IdMassage, objMess) {
         // перебирает count сообщений  вызывает событие в котором передает  вложения не включая last
         // найденное дописывается в конец IdMassage, objMess
+        var self = this;
         if (first == 'eof') {
             self.callEvent('getHistoryAttr', null, 'eof');
             return;


### PR DESCRIPTION
Среди личных сообщений трудно найти записи из групп или пересланные сообщения. Поиск по ним не ведется, кнопка "Показать вложения" отображает только картинки, аудио-видео, документы, к тому же, не позволяет переходить непосредственно к сообщению.
Данный модуль добавляет кнопку "Ссылки и репосты" в окно вложений  (диалог кнопка "Показать вложения").
При нажатии на нее отображается история wall, link, forward . Клик на дату позволяет перейти к нужному сообщению в диалоге, или сразу к записи в группе.
Пример:
![инфо1](https://cloud.githubusercontent.com/assets/24756493/21757260/38ad4628-d63d-11e6-836d-55d97a99a15d.jpg)
Еще пример:
![инфо2](https://cloud.githubusercontent.com/assets/24756493/21757261/38adbd92-d63d-11e6-9af9-bdf3f66d4448.jpg)
