### PR TITLE
restrict content script matches to vk

### DIFF
--- a/builds/chrome/manifest.json
+++ b/builds/chrome/manifest.json
@@ -9,7 +9,7 @@
      {
         "js": ["content_script.js"],
         "run_at": "document_start",
-        "matches": ["*://vk.com/*","*://*.vk.com/*","*://vkontakte.ru/*","*://*.vkontakte.ru/*","*://vk.me/*","*://*.vk.me/*"],
+        "matches": ["*://vk.com/*","*://*.vk.com/*","*://vkontakte.ru/*","*://*.vkontakte.ru/*","*://vk.me/*","*://*.vk.me/*","*://userapi.com/*","*://*.userapi.com/*"],
         "all_frames": true
      }
   ],

--- a/builds/chrome/manifest.json
+++ b/builds/chrome/manifest.json
@@ -9,7 +9,7 @@
      {
         "js": ["content_script.js"],
         "run_at": "document_start",
-        "matches": ["<all_urls>"],
+        "matches": ["*://vk.com/*","*://*.vk.com/*","*://vkontakte.ru/*","*://*.vkontakte.ru/*","*://vk.me/*","*://*.vk.me/*"],
         "all_frames": true
      }
   ],


### PR DESCRIPTION
(sorry my russian is very bad)

I understand wanting to keep "permissions":"*://*.*" to be able to develop new functions like the lastfm scrobbller but inserting the content scripts themselves **in every frame of every page** is a huge waste and unnecessary.  vk will not suddenly decide to change it's domain.  This change will insert the scripts in every vk domain, and in every iframe for those domains.