### PR TITLE
Export vk messages as json

### DIFF
--- a/source/vkopt.js
+++ b/source/vkopt.js
@@ -7424,7 +7424,7 @@ vkopt['messages'] = {
          <div id="saveldr" style="display:none; padding:8px; padding-top: 14px; text-align:center; width:360px;"><img src="/images/upload.gif"></div>
          <div id="save_btn_text" style="text-align:center">
             <div class="button_blue"><button onclick="vkopt.messages.get_history({vals.peer}); return false;">{lng.SaveHistory} *.html</button></div><br>
-
+            <div class="button_gray"><button onclick="vkopt.messages.get_history_json({vals.peer}); return false;">(*.json)</button></div><br>
             <div class="button_gray"><button onclick="toggle('msg_save_more'); return false;">(*.txt.zip)</button></div>
             <div id="msg_save_more" style="display:none;">
             <div class="button_gray"><button onclick="vkopt.messages.zip.txt({vals.peer}); return false;">{lng.SaveHistory}</button></div>
@@ -8454,6 +8454,18 @@ vkopt['messages'] = {
            var contents = JSON.parse(data);
            vkopt.messages.export_data(data);
         })
+   },
+   get_history_json(uid) {
+      var done = function(messages){
+         console.log(messages);
+         var json = JSON.stringify(messages, null, 2);
+         vkopt.save_file(json,"vk_messages_"+uid+".json");
+         show('save_btn_text');
+         val('save_btn_text', IDL('Done'));
+         hide('saveldr');
+      };
+
+      vkopt.messages.get_history(uid, done);
    },
    get_history:function(uid, callback, partial_callback, ver){
       ver = ver || '5.73';


### PR DESCRIPTION
Часто возникает необходимость иметь бэкап сообщений в машиночитаемом формате (в идеале JSON), для дальнейшего анализа.  

Этот MR добавляет функцию экспорта истории переписки в формате json (`get_history_json`) и соответствующую кнопку в диалоге сохранения сообщения
![image](https://user-images.githubusercontent.com/5827605/103241008-3fb67480-4952-11eb-801f-c98fa55cfa58.png)

Не заморачивался с формированием имени файла, по-моему так достаточно, если кто-то думает иначе, исправлю.